### PR TITLE
Add dset_fraction, distributed improvements, data-scaling configs

### DIFF
--- a/app/plan_common/datasets/droid_dset.py
+++ b/app/plan_common/datasets/droid_dset.py
@@ -61,7 +61,7 @@ class DROIDVideoDataset(torch.utils.data.Dataset):
         droid_to_rcasa_action_format: int = 1,
         local: bool = True,
         seed: int = None,
-        droid_fraction: float = 1.0,
+        dset_fraction: float = 1.0,
     ):
         self.data_path = data_path
         self.frames_per_clip = frames_per_clip
@@ -103,11 +103,11 @@ class DROIDVideoDataset(torch.utils.data.Dataset):
             debug = False
 
         # Apply dataset fraction slicing
-        if droid_fraction < 1.0:
+        if dset_fraction < 1.0:
             original_len = len(self.samples)
-            num_samples = max(1, int(original_len * droid_fraction))
+            num_samples = max(1, int(original_len * dset_fraction))
             self.samples = self.samples[:num_samples]
-            logger.info(f"Slicing dataset from {original_len} to {num_samples} samples ({droid_fraction*100:.1f}%)")
+            logger.info(f"Slicing dataset from {original_len} to {num_samples} samples ({dset_fraction*100:.1f}%)")
         else:
             logger.info(f"Not slicing DROID dataset, using {len(self.samples)} samples, 100% of video paths")
         # Taken from other custom datasets

--- a/app/plan_common/datasets/droid_traj_stats.py
+++ b/app/plan_common/datasets/droid_traj_stats.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Precompute DROID trajectory lengths and report which are long enough
+for a given ``dataset_fpcs`` (frames-per-clip) value.
+
+Only reads h5 state arrays (no video decoding), so it is fast.
+
+Usage examples
+--------------
+# mpk dataset (glob patterns)
+python -m app.plan_common.datasets.droid_traj_stats \
+    --data_path /path/to/droid \
+    --mpk_manifest_patterns "**/*.h5" \
+    --fps 4 \
+    --dataset_fpcs 5 10 16 20
+
+# decord dataset (CSV file)
+python -m app.plan_common.datasets.droid_traj_stats \
+    --data_path /path/to/droid_paths.csv \
+    --fps 4 \
+    --dataset_fpcs 5 10 16 20
+
+# Save trajectory lengths to a file (can be loaded later)
+python -m app.plan_common.datasets.droid_traj_stats \
+    --data_path /path/to/droid_paths.csv \
+    --fps 4 \
+    --dataset_fpcs 5 10 16 20 \
+    --output /path/to/seq_lengths.pkl
+"""
+
+import argparse
+import pickle
+from math import ceil
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+import h5py
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+VFPS = 30  # DROID recording fps
+
+
+def _load_mpk_paths(data_path: str, patterns: Sequence[str]) -> List[str]:
+    """Glob h5 files under *data_path* matching *patterns*."""
+    paths: List[str] = []
+    for pattern in patterns:
+        cleaned = pattern.lstrip("/")
+        found = list(Path(data_path).glob(cleaned))
+        if not found:
+            print(f"[warn] no files found for pattern {cleaned}")
+        paths.extend(str(p) for p in found)
+    return paths
+
+
+def _load_decord_paths(csv_path: str) -> List[str]:
+    """Read trajectory directory paths from a whitespace-delimited CSV."""
+    return list(pd.read_csv(csv_path, header=None, delimiter=" ").values[:, 0])
+
+
+def _get_vlen_mpk(path: str) -> Optional[int]:
+    """Return trajectory length from an mpk-style h5 file."""
+    try:
+        with h5py.File(path, "r") as f:
+            return f["episode_data"]["observation"]["cartesian_position"].shape[0]
+    except Exception as e:
+        print(f"[warn] could not read {path}: {e}")
+        return None
+
+
+def _get_vlen_decord(traj_dir: str) -> Optional[int]:
+    """Return trajectory length from a decord-style trajectory directory."""
+    h5_path = str(Path(traj_dir) / "trajectory.h5")
+    try:
+        with h5py.File(h5_path, "r") as f:
+            return f["observation"]["robot_state"]["cartesian_position"].shape[0]
+    except Exception as e:
+        print(f"[warn] could not read {h5_path}: {e}")
+        return None
+
+
+def _nframes_for_fpcs(dataset_fpcs: int, fps: int) -> int:
+    """Minimum number of raw frames required for *dataset_fpcs* at *fps*."""
+    fstp = ceil(VFPS / fps)
+    return int(dataset_fpcs * fstp)
+
+
+def load_seq_lengths(path: str) -> List[int]:
+    """Load precomputed trajectory lengths from a pickle file.
+
+    Args:
+        path: Path to the pickle file (e.g., seq_lengths.pkl).
+
+    Returns:
+        List of trajectory lengths.
+    """
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Report DROID trajectory length statistics."
+    )
+    parser.add_argument(
+        "--data_path",
+        type=str,
+        required=True,
+        help="Root directory (mpk) or CSV file path (decord).",
+    )
+    parser.add_argument(
+        "--mpk_manifest_patterns",
+        type=str,
+        nargs="+",
+        default=None,
+        help="Glob patterns for mpk h5 files (e.g. '**/*.h5').",
+    )
+    parser.add_argument(
+        "--fps",
+        type=int,
+        default=4,
+        help="Target sampling fps (default: 4).",
+    )
+    parser.add_argument(
+        "--dataset_fpcs",
+        type=int,
+        nargs="+",
+        required=True,
+        help="One or more frames-per-clip values to evaluate.",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Path to save trajectory lengths (pickle file, e.g., seq_lengths.pkl).",
+    )
+    args = parser.parse_args()
+
+    is_mpk = args.mpk_manifest_patterns is not None
+    if is_mpk:
+        paths = _load_mpk_paths(args.data_path, args.mpk_manifest_patterns)
+    else:
+        paths = _load_decord_paths(args.data_path)
+
+    print(f"Found {len(paths)} trajectories (mode={'mpk' if is_mpk else 'decord'})")
+
+    get_vlen = _get_vlen_mpk if is_mpk else _get_vlen_decord
+    vlens: List[int] = []
+    valid_paths: List[str] = []
+    for p in tqdm(paths, desc="Reading trajectory lengths"):
+        vl = get_vlen(p)
+        if vl is not None:
+            vlens.append(vl)
+            valid_paths.append(p)
+
+    vlens_arr = np.array(vlens)
+    total = len(vlens_arr)
+    print(f"\nTrajectory length statistics (n={total}):")
+    print(f"  min    = {vlens_arr.min()}")
+    print(f"  max    = {vlens_arr.max()}")
+    print(f"  median = {np.median(vlens_arr):.0f}")
+    print(f"  mean   = {vlens_arr.mean():.1f}")
+
+    print(f"\nRequired lengths per dataset_fpcs (fps={args.fps}, vfps={VFPS}):")
+    print(f"{'fpcs':>6}  {'nframes':>8}  {'valid':>8}  {'total':>8}  {'pct':>7}")
+    print("-" * 45)
+    for fpcs in sorted(args.dataset_fpcs):
+        nf = _nframes_for_fpcs(fpcs, args.fps)
+        valid = int((vlens_arr >= nf).sum())
+        pct = 100.0 * valid / total if total > 0 else 0.0
+        print(f"{fpcs:>6}  {nf:>8}  {valid:>8}  {total:>8}  {pct:>6.1f}%")
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "wb") as f:
+            pickle.dump(vlens, f)
+        print(f"\nSaved {len(vlens)} trajectory lengths to {output_path}")
+
+        paths_output = output_path.with_suffix(".paths.pkl")
+        with open(paths_output, "wb") as f:
+            pickle.dump(valid_paths, f)
+        print(f"Saved {len(valid_paths)} trajectory paths to {paths_output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/plan_common/datasets/metaworld_hf_dset.py
+++ b/app/plan_common/datasets/metaworld_hf_dset.py
@@ -70,6 +70,7 @@ class MetaworldHFDataset(TrajDataset):
         action_scale=1.0,
         filter_tasks: Optional[List[str]] = None,
         with_reward: bool = True,
+        dset_fraction: float = 1.0,
     ):
         self.data_path = Path(data_path)
         self.transform = transform
@@ -89,6 +90,11 @@ class MetaworldHFDataset(TrajDataset):
         if n_rollout is not None:
             ds = ds.select(range(min(n_rollout, len(ds))))
 
+        if dset_fraction < 1.0:
+            original_len = len(ds)
+            num_samples = max(1, int(original_len * dset_fraction))
+            ds = ds.select(range(num_samples))
+            log.info(f"Slicing Metaworld dataset from {original_len} to {num_samples} samples ({dset_fraction*100:.1f}%)")
         self.dataset = ds
         log.info(f"✅ Loaded {len(ds)} Metaworld rollouts")
 
@@ -217,6 +223,7 @@ def load_metaworld_hf_slice_train_val(
     random_seed=42,
     with_reward=False,
     process_actions="concat",
+    dset_fraction: float = 1.0,
 ):
     dset = MetaworldHFDataset(
         n_rollout=n_rollout,
@@ -225,6 +232,7 @@ def load_metaworld_hf_slice_train_val(
         normalize_action=normalize_action,
         filter_tasks=filter_tasks,
         with_reward=with_reward,
+        dset_fraction=dset_fraction,
     )
     dset_train, dset_val, train_slices, val_slices = get_train_val_sliced(
         traj_dataset=dset,

--- a/app/plan_common/datasets/point_maze_dset.py
+++ b/app/plan_common/datasets/point_maze_dset.py
@@ -23,6 +23,7 @@ class PointMazeDataset(TrajDataset):
         transform: Optional[Callable] = None,
         normalize_action: bool = False,
         action_scale=1.0,
+        dset_fraction: float = 1.0,
     ):
         self.data_path = Path(data_path)
         self.transform = transform
@@ -41,6 +42,13 @@ class PointMazeDataset(TrajDataset):
         self.states = self.states[:n]
         self.actions = self.actions[:n]
         self.seq_lengths = self.seq_lengths[:n]
+        if dset_fraction < 1.0:
+            num_keep = max(1, int(n * dset_fraction))
+            self.states = self.states[:num_keep]
+            self.actions = self.actions[:num_keep]
+            self.seq_lengths = self.seq_lengths[:num_keep]
+            log.info(f"Slicing PointMaze dataset from {n} to {num_keep} samples ({dset_fraction*100:.1f}%)")
+            n = num_keep
         self.proprios = self.states.clone()
         log.info(f"✅ Loaded {n} PointMaze rollouts")
 
@@ -120,12 +128,14 @@ def load_point_maze_slice_train_val(
     traj_subset=True,
     random_seed=42,
     process_actions="concat",
+    dset_fraction: float = 1.0,
 ):
     dset = PointMazeDataset(
         n_rollout=n_rollout,
         transform=transform,
         data_path=data_path,
         normalize_action=normalize_action,
+        dset_fraction=dset_fraction,
     )
     dset_train, dset_val, train_slices, val_slices = get_train_val_sliced(
         traj_dataset=dset,

--- a/app/plan_common/datasets/pusht_dset.py
+++ b/app/plan_common/datasets/pusht_dset.py
@@ -36,6 +36,7 @@ class PushTDataset(TrajDataset):
         relative=True,
         action_scale=100.0,
         with_velocity: bool = True,  # agent's velocity
+        dset_fraction: float = 1.0,
     ):
         self.data_path = Path(data_path)
         self.transform = transform
@@ -71,6 +72,7 @@ class PushTDataset(TrajDataset):
         self.states = self.states[:n]
         self.actions = self.actions[:n]
         self.seq_lengths = self.seq_lengths[:n]
+        self.shapes = self.shapes[:n]
         self.proprios = self.states[..., :2].clone()  # For pusht, first 2 dim of states is proprio
         # load velocities and update states and proprios
         self.with_velocity = with_velocity
@@ -79,6 +81,17 @@ class PushTDataset(TrajDataset):
             self.velocities = self.velocities[:n].float()
             self.states = torch.cat([self.states, self.velocities], dim=-1)
             self.proprios = torch.cat([self.proprios, self.velocities], dim=-1)
+        if dset_fraction < 1.0:
+            num_keep = max(1, int(n * dset_fraction))
+            self.states = self.states[:num_keep]
+            self.actions = self.actions[:num_keep]
+            self.seq_lengths = self.seq_lengths[:num_keep]
+            self.proprios = self.proprios[:num_keep]
+            self.shapes = self.shapes[:num_keep]
+            if with_velocity:
+                self.velocities = self.velocities[:num_keep]
+            log.info(f"Slicing PushT dataset from {n} to {num_keep} samples ({dset_fraction*100:.1f}%)")
+            n = num_keep
         log.info(f"✅ Loaded {n} PushT rollouts")
 
         self.action_dim = self.actions.shape[-1]
@@ -151,6 +164,7 @@ def load_pusht_slice_train_val(
     with_velocity=True,
     random_seed=42,
     process_actions="concat",
+    dset_fraction: float = 1.0,
 ):
     train_dset = PushTDataset(
         n_rollout=n_rollout,
@@ -158,6 +172,7 @@ def load_pusht_slice_train_val(
         data_path=data_path + "/train",
         normalize_action=normalize_action,
         with_velocity=with_velocity,
+        dset_fraction=dset_fraction,
     )
     val_dset = PushTDataset(
         n_rollout=n_rollout,
@@ -165,6 +180,7 @@ def load_pusht_slice_train_val(
         data_path=data_path + "/val",
         normalize_action=normalize_action,
         with_velocity=with_velocity,
+        dset_fraction=dset_fraction,
     )
 
     num_frames = num_hist + num_pred

--- a/app/plan_common/datasets/robocasa_dset.py
+++ b/app/plan_common/datasets/robocasa_dset.py
@@ -116,6 +116,7 @@ class RoboCasaDataset(TrajDataset):
         output_rcasa_info=False,
         rcasa_to_droid_action_format=False,
         custom_teleop_dset=False,
+        dset_fraction: float = 1.0,
     ):
         self.transform = transform
         self.data_path = data_path
@@ -246,6 +247,12 @@ class RoboCasaDataset(TrajDataset):
                 raise ValueError(f"No hdf5 files found for any of the specified tasks: {self.filter_tasks}")
 
         logger.info(f"Total dataset: {len(self.file_paths)} files across {len(self.filter_tasks)} tasks")
+
+        if dset_fraction < 1.0:
+            original_len = len(self.file_paths)
+            num_keep = max(1, int(original_len * dset_fraction))
+            self.file_paths = self.file_paths[:num_keep]
+            logger.info(f"Slicing RoboCasa dataset from {original_len} to {num_keep} files ({dset_fraction*100:.1f}%)")
 
         # Load data from all files
         for file_path in self.file_paths:
@@ -508,6 +515,7 @@ def load_robocasa_slice_train_val(
     rcasa_to_droid_action_format=False,
     process_actions="concat",
     custom_teleop_dset=False,
+    dset_fraction: float = 1.0,
 ):
     """
     Load RoboCasa dataset and split into train and validation sets.
@@ -549,6 +557,7 @@ def load_robocasa_slice_train_val(
         output_rcasa_info=output_rcasa_info,
         rcasa_to_droid_action_format=rcasa_to_droid_action_format,
         custom_teleop_dset=custom_teleop_dset,
+        dset_fraction=dset_fraction,
     )
 
     dset_train, dset_val, train_slices, val_slices = get_train_val_sliced(

--- a/app/plan_common/datasets/traj_dset.py
+++ b/app/plan_common/datasets/traj_dset.py
@@ -10,6 +10,8 @@ from einops import rearrange
 from torch import default_generator, randperm
 from torch.utils.data import Dataset
 
+from src.utils.logging import get_logger
+log = get_logger(__name__)
 
 # https://github.com/JaidedAI/EasyOCR/issues/1243
 def _accumulate(iterable, fn=lambda x, y: x + y):
@@ -100,7 +102,7 @@ class TrajSlicerDataset(TrajDataset):
         for i in range(len(self.dataset)):
             T = self.dataset.get_seq_length(i)
             if T - num_frames < 0:
-                print(f"Ignored short sequence #{i}: len={T}, num_frames={num_frames}")
+                log.info(f"Ignored short sequence #{i}: len={T}, num_frames={num_frames}")
             else:
                 self.slices += [
                     (i, start, start + num_frames * self.frameskip) for start in range(T - num_frames * frameskip + 1)
@@ -161,7 +163,7 @@ def random_split_traj(
     if sum(lengths) != len(dataset):  # type: ignore[arg-type]
         raise ValueError("Sum of input lengths does not equal the length of the input dataset!")
     indices = randperm(sum(lengths), generator=generator).tolist()
-    print([indices[offset - length : offset] for offset, length in zip(_accumulate(lengths), lengths)])
+    log.info([indices[offset - length : offset] for offset, length in zip(_accumulate(lengths), lengths)])
     if traj_subset:
         return [
             TrajSubset(dataset, indices[offset - length : offset])

--- a/app/plan_common/datasets/utils.py
+++ b/app/plan_common/datasets/utils.py
@@ -59,8 +59,8 @@ def init_data(
     dataset_fpcs=[16],
     mpk_manifest_patterns: list[str] = None,
     custom_teleop_dset=False,
-    droid_fraction=1,
-    val_droid_fraction=1,
+    dset_fraction=1,
+    val_dset_fraction=1,
     # RoboCasa-specific parameters
     output_rcasa_state=False,
     output_rcasa_info=False,
@@ -101,7 +101,7 @@ def init_data(
                 camera_frame=camera_frame,
                 droid_to_rcasa_action_format=droid_to_rcasa_action_format,
                 seed=seed,
-                droid_fraction=droid_fraction,
+                dset_fraction=dset_fraction,
                 action_skip=action_skip,
             )
             if val_data_paths:
@@ -116,7 +116,7 @@ def init_data(
                     camera_frame=camera_frame,
                     droid_to_rcasa_action_format=droid_to_rcasa_action_format,
                     seed=seed,
-                    droid_fraction=val_droid_fraction,
+                    dset_fraction=val_dset_fraction,
                     action_skip=action_skip,
                 )
             datasets = {"train": dataset, "valid": val_dataset}
@@ -138,6 +138,7 @@ def init_data(
                 with_reward=with_reward,
                 random_seed=seed,
                 process_actions=process_actions,
+                dset_fraction=dset_fraction,
             )
             dataset = datasets["train"]
             shuffle = True
@@ -156,6 +157,7 @@ def init_data(
                 with_velocity=True,
                 random_seed=seed,
                 process_actions=process_actions,
+                dset_fraction=dset_fraction,
             )
             dataset = datasets["train"]
             shuffle = False
@@ -175,6 +177,7 @@ def init_data(
                 traj_subset=traj_subset,
                 random_seed=seed,
                 process_actions=process_actions,
+                dset_fraction=dset_fraction,
             )
             dataset = datasets["train"]
             shuffle = False
@@ -193,6 +196,7 @@ def init_data(
                 traj_subset=traj_subset,
                 random_seed=seed,
                 process_actions=process_actions,
+                dset_fraction=dset_fraction,
             )
             dataset = datasets["train"]
         elif all("robocasa" in p for p in data_paths):
@@ -218,6 +222,7 @@ def init_data(
                 rcasa_to_droid_action_format=rcasa_to_droid_action_format,
                 custom_teleop_dset=custom_teleop_dset,
                 camera_views=val_dataset_camera_views,
+                dset_fraction=dset_fraction,
             )
             dataset = datasets["train"]
         else:

--- a/app/plan_common/datasets/wall_dset.py
+++ b/app/plan_common/datasets/wall_dset.py
@@ -28,6 +28,7 @@ class WallDataset(TrajDataset):
         transform: Optional[Callable] = None,
         normalize_action: bool = False,
         action_scale=1.0,
+        dset_fraction: float = 1.0,
     ):
         self.data_path = Path(data_path)
         self.transform = transform
@@ -53,6 +54,15 @@ class WallDataset(TrajDataset):
         self.proprios = self.proprios[:n]
         self.door_locations = self.door_locations[:n]
         self.wall_locations = self.wall_locations[:n]
+        if dset_fraction < 1.0:
+            num_keep = max(1, int(n * dset_fraction))
+            self.states = self.states[:num_keep]
+            self.actions = self.actions[:num_keep]
+            self.proprios = self.proprios[:num_keep]
+            self.door_locations = self.door_locations[:num_keep]
+            self.wall_locations = self.wall_locations[:num_keep]
+            log.info(f"Slicing Wall dataset from {n} to {num_keep} samples ({dset_fraction*100:.1f}%)")
+            n = num_keep
 
         self.action_dim = self.actions.shape[-1]
         self.state_dim = self.states.shape[-1]
@@ -123,6 +133,7 @@ def load_wall_slice_train_val(
     traj_subset=True,
     random_seed=42,
     process_actions="concat",
+    dset_fraction: float = 1.0,
 ):
     if split_mode == "random":
         dset = WallDataset(
@@ -130,6 +141,7 @@ def load_wall_slice_train_val(
             transform=transform,
             data_path=data_path,
             normalize_action=normalize_action,
+            dset_fraction=dset_fraction,
         )
         dset_train, dset_val, train_slices, val_slices = get_train_val_sliced(
             traj_dataset=dset,
@@ -148,12 +160,14 @@ def load_wall_slice_train_val(
             transform=transform,
             data_path=data_path + "/train",
             normalize_action=normalize_action,
+            dset_fraction=dset_fraction,
         )
         dset_val = WallDataset(
             n_rollout=n_rollout,
             transform=transform,
             data_path=data_path + "/val",
             normalize_action=normalize_action,
+            dset_fraction=dset_fraction,
         )
         num_frames = num_hist + num_pred
         train_slices = TrajSlicerDataset(

--- a/app/plan_common/plot/design_choice_yamls/W_extended.yaml
+++ b/app/plan_common/plot/design_choice_yamls/W_extended.yaml
@@ -1,0 +1,49 @@
+W=1: [
+  "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist1",
+  "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist1_save_2n",
+  "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist1_save",
+  "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist1_save_2n",
+  "${JEPAWM_LOGS}/droid_final_sweep/droid_4f_fps4_r224_pred_dino_wm_depth6_noprop_repro_1roll_2fpcs_2n",
+]
+W=2: [
+  "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist2",
+  "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist2_save_2n",
+  "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist2_save",
+  "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist2_save_2n",
+  "${JEPAWM_LOGS}/droid_final_sweep/droid_4f_fps4_r224_pred_dino_wm_depth6_noprop_repro_1roll_3fpcs_2n",
+]
+W=3: [
+  "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_seed1",
+  "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_2n",
+  "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save",
+  "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_2n",
+  "${JEPAWM_LOGS}/droid_final_sweep/droid_4f_fps4_r224_pred_dino_wm_depth6_noprop_repro_1roll_4fpcs_2n",
+]
+W=5: [
+  "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist5",
+  "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist5_save_2n",
+  "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist5_save",
+  "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist5_save_2n",
+  "${JEPAWM_LOGS}/droid_final_sweep/droid_4f_fps4_r224_pred_dino_wm_depth6_noprop_repro_1roll_6fpcs_2n",
+]
+W=7: [
+  "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist7",
+  "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_hist7_2n_lightfreq100",
+  "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_hist7",
+  "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist7_ipe418",
+  "${JEPAWM_LOGS}/droid_final_sweep/droid_4f_fps4_r224_pred_dino_wm_depth6_noprop_repro_1roll_8fpcs_2n"
+]
+W=9: [
+  "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9",
+  "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9",
+  "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9",
+  "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9_ipe418",
+  "${JEPAWM_LOGS}/droid_final_sweep/droid_10fpcs_fps4_r224_pred_dino_wm_depth6_noprop_repro_1roll",
+]
+W=14: [
+  "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist14",
+  "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist14",
+  "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist14",
+  # "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist14",
+  "${JEPAWM_LOGS}/droid_final_sweep/droid_15fpcs_fps4_r224_pred_dino_wm_depth6_noprop_repro_1roll",
+]

--- a/app/plan_common/plot/design_choice_yamls/data_scaling.yaml
+++ b/app/plan_common/plot/design_choice_yamls/data_scaling.yaml
@@ -1,0 +1,77 @@
+# design_choice_name: Data fractions in percentage
+2: [
+  Ours: [
+    # '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.02_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n',
+    '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.02_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save',
+    '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.02_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n',
+    '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.02_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save',
+    '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.02_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll',
+  ],
+  DWM: [
+    # '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.02_r224_pred_dino_wm_depth6_noprop_repro_1roll',
+    '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.02_r224_pred_dino_wm_depth6_repro_1roll_save',
+    '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.02_r224_pred_dino_wm_depth6_repro_1roll_save_2n',
+    '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.02_r224_pred_dino_wm_depth6_repro_1roll_save',
+    '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.02_r224_pred_dino_wm_depth6_repro_1roll'
+  ],
+  # VJ2AC: [
+  #   '${JEPAWM_LOGS}/droid_final_sweep/droid_8fpcs_fps4_frac0.02_r256_vj2acvitgL1_repro_2roll_noprop_4n_asp1_wsd',
+  # ]
+]
+10: [
+  Ours: [
+    # '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.1_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n',
+    '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.1_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save',
+    '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n',
+    '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save',
+    '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll',
+  ],
+  DWM: [
+    # '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.1_r224_pred_dino_wm_depth6_noprop_repro_1roll',
+    '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.1_r224_pred_dino_wm_depth6_repro_1roll_save',
+    '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.1_r224_pred_dino_wm_depth6_repro_1roll_save_2n',
+    '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.1_r224_pred_dino_wm_depth6_repro_1roll_save',
+    '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.1_r224_pred_dino_wm_depth6_repro_1roll'
+  ],
+  # VJ2AC: [
+  #   '${JEPAWM_LOGS}/droid_final_sweep/droid_8fpcs_fps4_frac0.1_r256_vj2acvitgL1_repro_2roll_noprop_4n_asp1_wsd',
+  # ]
+]
+50: [
+  Ours: [
+    # '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.5_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n',
+    '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.5_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save',
+    '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.5_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n',
+    '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.5_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save',
+    '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.5_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll',
+  ],
+  DWM: [
+    # '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.5_r224_pred_dino_wm_depth6_noprop_repro_1roll',
+    '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.5_r224_pred_dino_wm_depth6_repro_1roll_save',
+    '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.5_r224_pred_dino_wm_depth6_repro_1roll_save_2n',
+    '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.5_r224_pred_dino_wm_depth6_repro_1roll_save',
+    '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.5_r224_pred_dino_wm_depth6_repro_1roll'
+  ],
+  # VJ2AC: [
+  #   '${JEPAWM_LOGS}/droid_final_sweep/droid_8fpcs_fps4_frac0.5_r256_vj2acvitgL1_repro_2roll_noprop_4n_asp1_wsd',
+  # ]
+]
+100: [
+  Ours: [
+    # "${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n",
+    "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save",
+    "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n",
+    "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save",
+    "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n",
+  ],
+  DWM: [
+    # "${JEPAWM_LOGS}/droid_final_sweep/droid_4f_fps4_r224_pred_dino_wm_depth6_noprop_repro_1roll_4fpcs_2n",
+    "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_repro_1roll_save",
+    "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_pred_dino_wm_depth6_repro_1roll_save_2n",
+    "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_pred_dino_wm_depth6_repro_1roll_save",
+    "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_repro_1roll_save_2n",
+  ],
+  # VJ2AC: [
+  #   "${JEPAWM_LOGS}/droid_final_sweep/droid_8fpcs_r256_vj2acvitgL1_repro_2roll_noprop_4n_asp1_wsd"
+  # ]
+]

--- a/app/plan_common/plot/design_choice_yamls/data_scaling_droid_rcasa.yaml
+++ b/app/plan_common/plot/design_choice_yamls/data_scaling_droid_rcasa.yaml
@@ -1,0 +1,77 @@
+# design_choice_name: Data fractions in percentage
+2: [
+  Ours: [
+    '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.02_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n',
+    # '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.02_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save',
+    # '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.02_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n',
+    # '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.02_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save',
+    # '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.02_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll',
+  ],
+  DWM: [
+    '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.02_r224_pred_dino_wm_depth6_noprop_repro_1roll',
+    # '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.02_r224_pred_dino_wm_depth6_repro_1roll_save',
+    # '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.02_r224_pred_dino_wm_depth6_repro_1roll_save_2n',
+    # '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.02_r224_pred_dino_wm_depth6_repro_1roll_save',
+    # '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.02_r224_pred_dino_wm_depth6_repro_1roll'
+  ],
+  VJ2AC: [
+    '${JEPAWM_LOGS}/droid_final_sweep/droid_8fpcs_fps4_frac0.02_r256_vj2acvitgL1_repro_2roll_noprop_4n_asp1_wsd',
+  ]
+]
+10: [
+  Ours: [
+    '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.1_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n',
+    # '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.1_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save',
+    # '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n',
+    # '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save',
+    # '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll',
+  ],
+  DWM: [
+    '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.1_r224_pred_dino_wm_depth6_noprop_repro_1roll',
+    # '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.1_r224_pred_dino_wm_depth6_repro_1roll_save',
+    # '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.1_r224_pred_dino_wm_depth6_repro_1roll_save_2n',
+    # '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.1_r224_pred_dino_wm_depth6_repro_1roll_save',
+    # '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.1_r224_pred_dino_wm_depth6_repro_1roll'
+  ],
+  VJ2AC: [
+    '${JEPAWM_LOGS}/droid_final_sweep/droid_8fpcs_fps4_frac0.1_r256_vj2acvitgL1_repro_2roll_noprop_4n_asp1_wsd',
+  ]
+]
+50: [
+  Ours: [
+    '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.5_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n',
+    # '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.5_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save',
+    # '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.5_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n',
+    # '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.5_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save',
+    # '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.5_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll',
+  ],
+  DWM: [
+    '${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.5_r224_pred_dino_wm_depth6_noprop_repro_1roll',
+    # '${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.5_r224_pred_dino_wm_depth6_repro_1roll_save',
+    # '${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.5_r224_pred_dino_wm_depth6_repro_1roll_save_2n',
+    # '${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.5_r224_pred_dino_wm_depth6_repro_1roll_save',
+    # '${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.5_r224_pred_dino_wm_depth6_repro_1roll'
+  ],
+  VJ2AC: [
+    '${JEPAWM_LOGS}/droid_final_sweep/droid_8fpcs_fps4_frac0.5_r256_vj2acvitgL1_repro_2roll_noprop_4n_asp1_wsd',
+  ]
+]
+100: [
+  Ours: [
+    "${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n",
+    # "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save",
+    # "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n",
+    # "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save",
+    # "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n",
+  ],
+  DWM: [
+    "${JEPAWM_LOGS}/droid_final_sweep/droid_4f_fps4_r224_pred_dino_wm_depth6_noprop_repro_1roll_4fpcs_2n",
+    # "${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_repro_1roll_save",
+    # "${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_r224_pred_dino_wm_depth6_repro_1roll_save_2n",
+    # "${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_r224_pred_dino_wm_depth6_repro_1roll_save",
+    # "${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_repro_1roll_save_2n",
+  ],
+  VJ2AC: [
+    "${JEPAWM_LOGS}/droid_final_sweep/droid_8fpcs_r256_vj2acvitgL1_repro_2roll_noprop_4n_asp1_wsd"
+  ]
+]

--- a/app/plan_common/plot/logs_plan_joint_per_design_choice.py
+++ b/app/plan_common/plot/logs_plan_joint_per_design_choice.py
@@ -30,6 +30,52 @@ from src.utils.yaml_utils import expand_env_vars
 JEPAWM_LOGS = os.environ.get("JEPAWM_LOGS", "~")
 base_dir = "app/plan_common/local/plan_joint_per_design_choice"
 
+
+def is_multi_method_yaml(design_choices: dict) -> bool:
+    """Check if the YAML contains multi-method entries (ordinal -> [{method: [paths]}])."""
+    for key, value in design_choices.items():
+        if key == "design_choice_name":
+            continue
+        if isinstance(value, list) and len(value) > 0:
+            if isinstance(value[0], dict):
+                return True
+    return False
+
+
+def flatten_multi_method_yaml(design_choices: dict) -> tuple:
+    """Flatten a multi-method YAML into single-method format plus a reverse mapping.
+
+    Args:
+        design_choices: Dict where ordinal keys map to lists of
+            single-key dicts [{method: [paths]}, ...].
+
+    Returns:
+        Tuple of (flat_design_choices, model_to_method) where:
+        - flat_design_choices: {ordinal: [all_paths_across_methods]}
+        - model_to_method: {model_path: method_name}
+    """
+    flat_design_choices = {}
+    model_to_method = {}
+    for key, value in design_choices.items():
+        if key == "design_choice_name":
+            flat_design_choices[key] = value
+            continue
+        if isinstance(value, list):
+            all_paths = []
+            for item in value:
+                if isinstance(item, dict):
+                    for method_name, paths in item.items():
+                        if isinstance(paths, list):
+                            all_paths.extend(paths)
+                            for p in paths:
+                                model_to_method[p] = method_name
+                elif isinstance(item, str):
+                    all_paths.append(item)
+            flat_design_choices[key] = all_paths
+        else:
+            flat_design_choices[key] = value
+    return flat_design_choices, model_to_method
+
 task_groups_mapping = {
     "droid": "DROID",
     "pt": "Push-T",
@@ -710,6 +756,143 @@ def aggregate_task_data_by_groups(
     return results
 
 
+def aggregate_task_data_by_groups_multi_method(
+    task_eval_data,
+    design_choices,
+    task_groups_mapping,
+    model_to_method,
+    last_n_epochs={},
+    start_from_epoch={},
+    use_computed_best_eval_setup=False,
+    std_average_group=False,
+):
+    """Aggregate task data with an additional method dimension.
+
+    Args:
+        task_eval_data: Data collected using collect_task_eval_data function.
+        design_choices: Dict mapping ordinal labels to lists of model paths (flattened).
+        task_groups_mapping: Dict mapping task names to display names.
+        model_to_method: Dict mapping model paths to method names.
+        last_n_epochs: Dict mapping task names to number of last epochs to aggregate over.
+        start_from_epoch: Dict mapping task names to starting epoch index.
+        use_computed_best_eval_setup: Whether to pick the best eval setup per task group.
+        std_average_group: Whether to propagate std for the Avg group.
+
+    Returns:
+        dict: {task_group: {method: {design_choice: (mean, std, count)}}}
+    """
+    model_to_design = {}
+    for design, model_paths in design_choices.items():
+        if design == "design_choice_name":
+            continue
+        for path in model_paths:
+            model_to_design[path] = design
+
+    eval_setup_data = defaultdict(list)
+
+    for (model_path, task_name, eval_setup, seed), df in task_eval_data.items():
+        if task_name not in task_groups_mapping:
+            continue
+
+        if model_path not in model_to_design:
+            parent_path = os.path.dirname(model_path)
+            if parent_path in model_to_design:
+                model_to_design[model_path] = model_to_design[parent_path]
+                if parent_path in model_to_method:
+                    model_to_method[model_path] = model_to_method[parent_path]
+
+        design_choice = model_to_design.get(model_path)
+        method = model_to_method.get(model_path)
+        if design_choice is None or method is None:
+            continue
+
+        task_group = task_groups_mapping[task_name]
+        key = (task_group, method, design_choice, eval_setup)
+
+        if task_name == "droid":
+            if "Act_err_xyz" in df.columns and not df["Act_err_xyz"].isnull().any():
+                metric_values = np.maximum(0, 800 * (0.1 - df["Act_err_xyz"]))
+            else:
+                continue
+        else:
+            metric_values = df["SR"]
+
+        epochs = df["epoch"].values
+        if task_name in start_from_epoch:
+            mask = epochs >= start_from_epoch[task_name]
+            filtered_metric_values = metric_values[mask]
+        else:
+            filtered_metric_values = metric_values
+
+        task_specific_last_n = last_n_epochs.get(task_name, 10)
+        if len(filtered_metric_values) >= task_specific_last_n:
+            last_n_values = filtered_metric_values.iloc[-task_specific_last_n:].values
+        else:
+            last_n_values = (
+                filtered_metric_values.values if hasattr(filtered_metric_values, "values") else filtered_metric_values
+            )
+
+        eval_setup_data[key].extend(last_n_values)
+
+    # Pick best eval setup per (task_group, method, design_choice)
+    best_results = {}
+    for (task_group, method, design_choice, eval_setup), values in eval_setup_data.items():
+        values = np.array(values)
+        mean_perf = np.mean(values) if len(values) > 0 else 0
+        std_perf = np.std(values) if len(values) > 0 else 0
+        n_samples = len(values)
+
+        if use_computed_best_eval_setup:
+            rkey = (task_group, method, design_choice)
+            if rkey not in best_results or mean_perf > best_results[rkey][0]:
+                best_results[rkey] = (mean_perf, std_perf, n_samples)
+        else:
+            if eval_setup != best_eval_setup_per_task_group.get(task_group):
+                continue
+            best_results[(task_group, method, design_choice)] = (mean_perf, std_perf, n_samples)
+
+    # Structure: {task_group: {method: {design_choice: (mean, std, count)}}}
+    results = {}
+    for (task_group, method, design_choice), (mean, std, count) in best_results.items():
+        results.setdefault(task_group, {}).setdefault(method, {})[design_choice] = (mean, std, count)
+
+    # Compute Avg across task groups for each (method, design_choice)
+    all_methods = set()
+    all_designs = set()
+    for tg_data in results.values():
+        for method, dc_data in tg_data.items():
+            all_methods.add(method)
+            all_designs.update(dc_data.keys())
+
+    task_groups_list = [tg for tg in results if tg != "Avg"]
+    avg_data = {}
+    for method in all_methods:
+        avg_data[method] = {}
+        for design in all_designs:
+            values = []
+            for task_group in task_groups_list:
+                if method in results.get(task_group, {}) and design in results[task_group][method]:
+                    mean, _, count = results[task_group][method][design]
+                    if count > 0:
+                        values.append(mean)
+            if values:
+                mean_value = np.mean(values)
+                if std_average_group:
+                    combined_variance = sum(
+                        results[tg][method][design][1] ** 2
+                        for tg in task_groups_list
+                        if method in results.get(tg, {}) and design in results[tg][method]
+                    )
+                    std_value = np.sqrt(combined_variance)
+                else:
+                    std_value = 0
+                avg_data[method][design] = (mean_value, std_value, sum(1 for _ in values))
+
+    results["Avg"] = avg_data
+    print(f"Multi-method aggregated results: {list(results.keys())} task groups, methods: {list(all_methods)}")
+    return results
+
+
 def aggregate_task_data_by_eval_setup(
     task_eval_data,
     eval_setup_aliases,
@@ -1006,6 +1189,8 @@ def plot_design_choices_line(
     std_average_group=False,
     offset_markers=True,
     highlight_task_groups=None,
+    avg_design_choices=None,
+    color_offset=0,
 ):
     """
     Create a line plot showing performance trends across ordered design choices.
@@ -1057,7 +1242,8 @@ def plot_design_choices_line(
     fig, ax = plt.subplots(figsize=figsize)
 
     # Set up colors
-    colors = sns.color_palette(color_palette, len(task_groups) + 1)  # +1 for Average
+    colors = sns.color_palette(color_palette, len(task_groups) + 1 + color_offset)  # +1 for Average
+    colors = colors[color_offset:]
     markers = ["o", "s", "^", "v", "D", "P", "X", "*", "h", "p", "<", ">", "8"]
 
     # Create x-axis positions for the design choices
@@ -1117,22 +1303,27 @@ def plot_design_choices_line(
             )
 
     if "Avg" in aggregated_data:
-        means = []
-        stds = []
+        avg_means = []
+        avg_stds = []
+        avg_x = []
 
-        for design in design_names:
+        for xi, design in enumerate(design_names):
+            if avg_design_choices is not None and design not in avg_design_choices:
+                continue
             if design in aggregated_data["Avg"]:
                 mean, std, _ = aggregated_data["Avg"][design]
-                means.append(mean)
-                stds.append(std)
+                avg_means.append(mean)
+                avg_stds.append(std)
+                avg_x.append(x_pos[xi])
             else:
-                means.append(0)
-                stds.append(0)
+                avg_means.append(0)
+                avg_stds.append(0)
+                avg_x.append(x_pos[xi])
 
         ax.errorbar(
-            x_pos,
-            means,
-            yerr=stds,
+            avg_x,
+            avg_means,
+            yerr=avg_stds,
             fmt="o-" if connect_means else "o",
             capsize=3,
             label="Avg",
@@ -1152,6 +1343,242 @@ def plot_design_choices_line(
 
     ax.legend(fontsize=9, loc="center left", bbox_to_anchor=(1, 0.5))
 
+    plt.tight_layout()
+
+    if save_path:
+        plt.savefig(save_path, dpi=dpi, bbox_inches="tight")
+        print(f"Figure saved to: {save_path}")
+
+    return fig
+
+
+def plot_design_choices_line_multi_method(
+    task_eval_data,
+    design_choices,
+    task_groups_mapping,
+    model_to_method,
+    last_n_epochs=10,
+    start_from_epoch={},
+    figsize=(6, 4),
+    dpi=300,
+    save_path=None,
+    use_computed_best_eval_setup=False,
+    std_average_group=False,
+    highlight_task_groups=None,
+    offset_markers=True,
+    skip_avg_methods=None,
+    avg_design_choices=None,
+    color_offset=0,
+):
+    """Line plot with color=dataset, marker=method for multi-method YAML files.
+
+    Args:
+        task_eval_data: Data collected using collect_task_eval_data function.
+        design_choices: Flattened dict mapping ordinal labels to lists of model paths.
+        task_groups_mapping: Dict mapping task names to display names.
+        model_to_method: Dict mapping model paths to method names.
+        last_n_epochs: Dict, key=task_group: value=Number of last epochs to aggregate.
+        start_from_epoch: Dict mapping task names to starting epoch index.
+        figsize: Figure size.
+        dpi: DPI for saved figure.
+        save_path: Optional path to save the figure.
+        use_computed_best_eval_setup: Whether to pick the best eval setup per task group.
+        std_average_group: Whether to propagate std for the Avg group.
+        highlight_task_groups: List of task group names to highlight with full lines.
+        offset_markers: Whether to apply small horizontal offsets to markers
+            so that overlapping points at the same x-coordinate are easier to
+            distinguish.
+        skip_avg_methods: Optional list of method names to exclude from the
+            Avg mean marker and line.
+
+    Returns:
+        matplotlib.figure.Figure: The created figure.
+    """
+    sns.set_theme()
+
+    if "design_choice_name" in design_choices:
+        design_choice_name = design_choices.pop("design_choice_name")
+        design_names = [k for k in design_choices.keys() if k != "design_choice_name"]
+    else:
+        design_names = list(design_choices.keys())
+        design_choice_name = ""
+
+    aggregated_data = aggregate_task_data_by_groups_multi_method(
+        task_eval_data,
+        design_choices,
+        task_groups_mapping,
+        model_to_method,
+        last_n_epochs,
+        start_from_epoch=start_from_epoch,
+        use_computed_best_eval_setup=use_computed_best_eval_setup,
+        std_average_group=std_average_group,
+    )
+
+    task_groups = [g for g in aggregated_data.keys() if g != "Avg"]
+
+    all_methods = set()
+    for tg_data in aggregated_data.values():
+        all_methods.update(tg_data.keys())
+    method_names = sorted(all_methods)
+
+    METHOD_MARKERS = {"Ours": "o", "DWM": "s", "VJ2AC": "^"}
+    fallback_markers = ["o", "s", "^", "v", "D", "P", "X", "*", "h", "p"]
+    for i, m in enumerate(method_names):
+        if m not in METHOD_MARKERS:
+            METHOD_MARKERS[m] = fallback_markers[i % len(fallback_markers)]
+
+    fig, ax = plt.subplots(figsize=figsize)
+    x_pos = np.arange(len(design_names))
+
+    # Calculate horizontal offsets to distribute markers by method.
+    # All markers for the 1st method go on the left offset,
+    # 2nd method on center (offset zero), 3rd method on the right offset.
+    if offset_markers:
+        n_methods = len(method_names)
+        if n_methods == 1:
+            method_to_offset = {method_names[0]: 0.0}
+        else:
+            offsets_list = np.linspace(-0.1, 0.1, n_methods)
+            method_to_offset = {m: offsets_list[i] for i, m in enumerate(method_names)}
+    else:
+        method_to_offset = {m: 0.0 for m in method_names}
+
+    colors = sns.color_palette("tab10", len(task_groups) + color_offset)
+    colors = colors[color_offset:]
+    task_group_colors = {tg: colors[i] for i, tg in enumerate(task_groups)}
+
+    for tg_idx, task_group in enumerate(task_groups):
+        tg_methods = aggregated_data.get(task_group, {})
+        color = task_group_colors[task_group]
+
+        for method in method_names:
+            if method not in tg_methods:
+                continue
+            dc_data = tg_methods[method]
+            means = []
+            stds = []
+            valid_x = []
+
+            for xi, design in enumerate(design_names):
+                if avg_design_choices is not None and design not in avg_design_choices:
+                    continue
+                if design in dc_data:
+                    mean, std, count = dc_data[design]
+                    if count > 0:
+                        means.append(mean)
+                        stds.append(std)
+                        valid_x.append(x_pos[xi])
+                    else:
+                        means.append(np.nan)
+                        stds.append(np.nan)
+                        valid_x.append(x_pos[xi])
+                else:
+                    means.append(np.nan)
+                    stds.append(np.nan)
+                    valid_x.append(x_pos[xi])
+
+            means = np.array(means)
+            stds = np.array(stds)
+            valid_x = np.array(valid_x)
+            mask = ~np.isnan(means)
+
+            if not mask.any():
+                continue
+
+            marker = METHOD_MARKERS.get(method, "o")
+            is_highlighted = highlight_task_groups and task_group in highlight_task_groups
+            label = f"{method} / {task_group}"
+            x_offset = method_to_offset[method]
+
+            if is_highlighted:
+                ax.errorbar(
+                    valid_x[mask] + x_offset,
+                    means[mask],
+                    yerr=stds[mask],
+                    fmt=f"{marker}-",
+                    capsize=3,
+                    label=label,
+                    color=color,
+                    linewidth=1.5,
+                    markersize=7,
+                    alpha=0.8,
+                )
+            else:
+                ax.errorbar(
+                    valid_x[mask] + x_offset,
+                    means[mask],
+                    yerr=stds[mask],
+                    fmt=marker,
+                    capsize=3,
+                    label=label,
+                    color=color,
+                    alpha=0.4,
+                )
+
+    # Avg lines per method
+    if "Avg" in aggregated_data:
+        avg_methods = aggregated_data["Avg"]
+        for method in method_names:
+            if skip_avg_methods and method in skip_avg_methods:
+                continue
+            if method not in avg_methods:
+                continue
+            dc_data = avg_methods[method]
+            means = []
+            stds = []
+            valid_x = []
+            for xi, design in enumerate(design_names):
+                if design in dc_data:
+                    mean, std, count = dc_data[design]
+                    if count > 0:
+                        means.append(mean)
+                        stds.append(std)
+                        valid_x.append(x_pos[xi])
+
+            if not means:
+                continue
+
+            marker = METHOD_MARKERS.get(method, "o")
+            x_offset = method_to_offset.get(method, 0.0)
+            ax.errorbar(
+                np.array(valid_x) + x_offset,
+                means,
+                yerr=stds,
+                fmt=f"{marker}--",
+                capsize=3,
+                label=f"Avg ({method})",
+                color="black",
+                linewidth=2.0,
+                markersize=8,
+                alpha=0.6,
+            )
+
+    ax.set_ylabel("Performance (%)", fontsize=10)
+    ax.set_xlabel(design_choice_name, fontsize=10)
+    ax.set_xticks(x_pos)
+    ax.set_xticklabels([str(d) for d in design_names], fontsize=9)
+    ax.set_ylim(0, 100)
+    ax.grid(axis="y", linestyle="--", alpha=0.7)
+
+    # Two-part legend: color patches for datasets, marker symbols for methods
+    from matplotlib.lines import Line2D
+    from matplotlib.patches import Patch
+
+    legend_handles = []
+    # legend_handles.append(Patch(facecolor="white", edgecolor="white", label="Datasets:"))
+    legend_handles.append(Line2D([], [], linestyle="None", label="Datasets:"))
+    for tg in task_groups:
+        legend_handles.append(Patch(facecolor=task_group_colors[tg], label=tg, alpha=0.7))
+    legend_handles.append(Line2D([], [], linestyle="None", label=""))
+    # legend_handles.append(Patch(facecolor="white", edgecolor="white", label="Methods:"))
+    legend_handles.append(Line2D([], [], linestyle="None", label="Methods:"))
+    for method in method_names:
+        marker = METHOD_MARKERS.get(method, "o")
+        legend_handles.append(
+            Line2D([0], [0], marker=marker, color="gray", linestyle="None", markersize=7, label=method)
+        )
+
+    ax.legend(handles=legend_handles, fontsize=8, loc="center left", bbox_to_anchor=(1, 0.5))
     plt.tight_layout()
 
     if save_path:
@@ -1538,6 +1965,11 @@ def main():
         python app/plan_common/plot/logs_plan_joint_per_design_choice.py --design_choices_file app/plan_common/plot/design_choice_yamls/prop.yaml --output prop_comparison --verbose --exclude_robocasa
         python app/plan_common/plot/logs_plan_joint_per_design_choice.py --design_choices_file app/plan_common/plot/design_choice_yamls/final_baseline_comp.yaml --output final_baseline_comp --generate_latex --verbose
 
+        python app/plan_common/plot/logs_plan_joint_per_design_choice.py --design_choices_file app/plan_common/plot/design_choice_yamls/data_scaling.yaml --output data_scaling_comparison --plot_line --verbose --skip_avg_methods "Ours,DWM,VJ2AC" --highlight_task_groups "Push-T","Wall","Maze","MW-\nReach","MW-\nReach-\nWall"
+        python app/plan_common/plot/logs_plan_joint_per_design_choice.py --design_choices_file app/plan_common/plot/design_choice_yamls/data_scaling_droid_rcasa.yaml --output data_scaling_droid_rcasa_comparison --plot_line --verbose --skip_avg_methods "Ours,DWM,VJ2AC" --highlight_task_groups "DROID","Rc-R","Rc-Pl" --color_offset 5
+
+        python app/plan_common/plot/logs_plan_joint_per_design_choice.py --design_choices_file app/plan_common/plot/design_choice_yamls/W_extended.yaml --output W_extended_comparison --plot_line --verbose --highlight_task_groups "DROID" --avg_design_choices "W=1,W=2,W=3,W=5,W=7,W=9"
+
         Test:
         python app/plan_common/plot/logs_plan_joint_per_design_choice.py --design_choices_file app/plan_common/plot/design_choice_yamls/test_n_epochs.yaml --output test_n_epochs --generate_latex --verbose
         python app/plan_common/plot/logs_plan_joint_per_design_choice.py --design_choices_file app/plan_common/plot/design_choice_yamls/test_n_epochs.yaml --output test_n_epochs --generate_latex --verbose --cut_eval_setup ep
@@ -1613,9 +2045,27 @@ def main():
         help='Comma-separated list of task group names to highlight with full lines in line plots. Example: "DROID"',
     )
     parser.add_argument(
+        "--skip_avg_methods",
+        type=str,
+        default=None,
+        help='Comma-separated list of method names to exclude from the Avg line. Example: "VJ2AC"',
+    )
+    parser.add_argument(
+        "--avg_design_choices",
+        type=str,
+        default=None,
+        help='Comma-separated list of design choice names to include in the Avg line/markers. Example: "W=1,W=2,W=3,W=5,W=7,W=9"',
+    )
+    parser.add_argument(
         "--exclude_robocasa",
         action="store_true",
         help="Exclude robocasa tasks (Rc-R, Rc-P, Rc-Pl, Rc-RP, Rc-PP, Rc-RPP) from the analysis",
+    )
+    parser.add_argument(
+        "--color_offset",
+        type=int,
+        default=0,
+        help="Offset into the color palette to avoid color collisions between separate plots",
     )
     args = parser.parse_args()
 
@@ -1640,6 +2090,16 @@ def main():
         design_choices = yaml.load(f)
     design_choices = expand_env_vars(design_choices)
 
+    # Detect multi-method YAML format and flatten if needed
+    is_multi_method = is_multi_method_yaml(design_choices)
+    model_to_method_map = {}
+    if is_multi_method:
+        flat_design_choices, model_to_method_map = flatten_multi_method_yaml(design_choices)
+        if args.verbose:
+            print(f"Detected multi-method YAML with methods: {set(model_to_method_map.values())}")
+    else:
+        flat_design_choices = design_choices
+
     save_file = Path(f"{base_dir}/{args.output}.pdf")
     os.makedirs(os.path.dirname(save_file), exist_ok=True)
 
@@ -1656,15 +2116,15 @@ def main():
     model_paths = []
     # Check if design_choices has a design_choice_name key
     design_choice_name = None
-    if "design_choice_name" in design_choices:
-        design_choice_name = design_choices.get("design_choice_name")
+    if "design_choice_name" in flat_design_choices:
+        design_choice_name = flat_design_choices.get("design_choice_name")
         # Only iterate through the actual design choices (not the name)
-        for key, paths in design_choices.items():
+        for key, paths in flat_design_choices.items():
             if key != "design_choice_name":
                 model_paths.extend(paths)
     else:
         # Original behavior if no design_choice_name is present
-        for paths in design_choices.values():
+        for paths in flat_design_choices.values():
             model_paths.extend(paths)
 
     if args.verbose:
@@ -1710,22 +2170,58 @@ def main():
             # Parse highlight_task_groups if provided
             highlight_groups = None
             if args.highlight_task_groups:
-                highlight_groups = [g.strip() for g in args.highlight_task_groups.split(",")]
+                highlight_groups = [
+                    g.strip().encode().decode("unicode_escape")
+                    for g in args.highlight_task_groups.split(",")
+                ]
 
-            fig = plot_design_choices_line(
-                task_eval_data,
-                design_choices,
-                task_groups_mapping,
-                last_n_epochs=effective_last_n_epochs,
-                start_from_epoch=effective_start_from_epoch,
-                figsize=figsize,
-                save_path=save_file,
-                dpi=args.dpi,
-                connect_means=True,
-                use_computed_best_eval_setup=args.use_computed_best_eval_setup,
-                std_average_group=args.std_average_group,
-                highlight_task_groups=highlight_groups,
-            )
+            if is_multi_method:
+                fig = plot_design_choices_line_multi_method(
+                    task_eval_data,
+                    flat_design_choices,
+                    task_groups_mapping,
+                    model_to_method_map,
+                    last_n_epochs=effective_last_n_epochs,
+                    start_from_epoch=effective_start_from_epoch,
+                    figsize=figsize,
+                    save_path=save_file,
+                    dpi=args.dpi,
+                    use_computed_best_eval_setup=args.use_computed_best_eval_setup,
+                    std_average_group=args.std_average_group,
+                    highlight_task_groups=highlight_groups,
+                    skip_avg_methods=(
+                        [m.strip() for m in args.skip_avg_methods.split(",")]
+                        if args.skip_avg_methods
+                        else None
+                    ),
+                    avg_design_choices=(
+                        [c.strip() for c in args.avg_design_choices.split(",")]
+                        if args.avg_design_choices
+                        else None
+                    ),
+                    color_offset=args.color_offset,
+                )
+            else:
+                fig = plot_design_choices_line(
+                    task_eval_data,
+                    design_choices,
+                    task_groups_mapping,
+                    last_n_epochs=effective_last_n_epochs,
+                    start_from_epoch=effective_start_from_epoch,
+                    figsize=figsize,
+                    save_path=save_file,
+                    dpi=args.dpi,
+                    connect_means=True,
+                    use_computed_best_eval_setup=args.use_computed_best_eval_setup,
+                    std_average_group=args.std_average_group,
+                    highlight_task_groups=highlight_groups,
+                    avg_design_choices=(
+                        [c.strip() for c in args.avg_design_choices.split(",")]
+                        if args.avg_design_choices
+                        else None
+                    ),
+                    color_offset=args.color_offset,
+                )
         elif args.generate_latex_all:
             # Parse planners_to_include if provided
             planners_list = None

--- a/app/vjepa_wm/train.py
+++ b/app/vjepa_wm/train.py
@@ -364,8 +364,8 @@ def main(args, resume_preempt=False):
         data_kwargs_1 = data_kwargs.copy()
         data_kwargs_1.update(
             {
-                "droid_fraction": 1,
-                "val_droid_fraction": 1,
+                "dset_fraction": 1,
+                "val_dset_fraction": 1,
                 "data_paths": val_datasets_1_paths,
                 "val_data_paths": val_datasets_1_paths,
                 "batch_size": val_datasets_1.get("batch_size", 4),

--- a/configs/vjepa_wm/droid_final_sweep/droid_4fpcs_fps4_frac0.1_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n.yaml
+++ b/configs/vjepa_wm/droid_final_sweep/droid_4fpcs_fps4_frac0.1_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n.yaml
@@ -1,0 +1,278 @@
+app: vjepa_wm
+nodes: 4
+tasks_per_node: 8
+cpus_per_task: 16
+folder: ${JEPAWM_LOGS}/droid_final_sweep/droid_4fpcs_fps4_frac0.1_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n
+checkpoint_folder: ${JEPAWM_CKPT}/droid_final_sweep/droid_4fpcs_fps4_frac0.1_r256_dv3vitl_asp1_pred_AdaLN_depth12_noprop_repro_2roll_4n
+data:
+  # Dataset configuration
+  dataset_type: custom
+  datasets:
+    - DROID
+  datasets_weights: null
+  seed: 234
+  dset_fraction: 0.1
+  img_size: 256
+  # Validation configuration
+  validation:
+    val_datasets:
+      - Franka_hf
+    num_frames_val: 5
+    val_dataset_batch_size: 4
+    val_dataset_drop_last: false
+    val_dataset_fpcs: [5]
+    val_dataset_camera_views: ["exterior_image_2_left"]
+    val_viz_rank0_loader: true
+    val_datasets_1:
+      names:
+        - Franka_hf
+      batch_size: 4
+      drop_last: False
+      fps: 4
+      fpcs:
+        - 5
+      camera_views:
+        - exterior_image_2_left
+  # DataLoader configuration
+  loader:
+    batch_size: 8
+    num_workers: 16
+    pin_mem: true
+    persistent_workers: true
+  # Custom dataset parameters
+  custom:
+    split_ratio: null
+    frameskip: 1
+    action_skip: 1
+    state_skip: 1
+    normalize_action: false
+    traj_subset: true
+    filter_first_episodes: null
+    filter_tasks: null
+    num_hist: null
+    num_pred: null
+    with_reward: null
+    custom_teleop_dset: null
+  # Droid-specific parameters
+  droid:
+    camera_frame: null
+    camera_views:
+      - left_mp4_path
+    droid_to_rcasa_action_format: 1
+    rcasa_to_droid_action_format: null
+    fps: 4
+    dataset_fpcs: [4]
+    # comment out all except liftcup_v0 for counterfactuals
+    mpk_manifest_patterns: [
+      '**/pick/liftcup_v0/run_0001/episode.h5',
+      '**/pick/pickandplaceredcube_v0/run_0001/episode.h5',
+      '**/pick/pickcube_v0/run_0001/episode.h5',
+      '**/pick/pickpen_v0/run_0001/episode.h5',
+      '**/pick/pickupcup_v0/run_0001/episode.h5',
+      '**/pick/reachcup_v0/run_0001/episode.h5',
+      '**/pick/reachliftcup_v0/run_0001/episode.h5',
+      '**/pick/reachliftcup_v1/run_0001/episode.h5',
+
+      '**/push/brownboxpush_v0/run_0001/episode.h5',
+
+      '**/push/push_various_objects/blue_bowl/episode.h5',
+      '**/push/push_various_objects/blue_box/episode.h5',
+      '**/push/push_various_objects/cap/episode.h5',
+      '**/push/push_various_objects/pengiun_plush/episode.h5',
+
+      '**/folding/foldjacketsleeve_v0/run_0001/episode.h5',
+      '**/folding/foldjacketsleeve_v1/run_0001/episode.h5'
+    ]
+data_aug:
+  auto_augment: false
+  random_horizontal_flip: false
+  motion_shift: false
+  random_resize_aspect_ratio:
+  - 1.
+  - 1.
+  random_resize_scale:
+  - 1.777
+  - 1.777
+  reprob: 0.0
+  normalize: [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
+logging:
+  write_tag: jepa
+  wandb:
+    use_wandb: true
+    debug: false
+    project: vjepa_wm
+    disable_wandb_media: true
+    log_media_locally: true
+loss:
+  cos_loss_weight: 0.0
+  l1_loss_weight: 0.0
+  l2_loss_weight: 1.0
+  smooth_l1_loss_weight: 0.0
+meta:
+  plan_only_eval_mode: true
+  light_eval_only_mode: false
+  unroll_decode_eval_only_mode: false
+  quick_debug: false
+  freeze_encoder: true
+  load_checkpoint: true
+  load_opt_scale_epoch: true
+  read_checkpoint: null
+  seed: 234
+  eval_freq: 6
+  light_eval_freq: 200
+  save_every_freq: 6
+  dtype: bfloat16
+  data_traj_rollout_eval:
+    do_data_traj_rollout_eval: true
+    data_traj_eval_rollout_steps: 6
+    data_traj_decode_gt: true
+    data_traj_eval_ctxt_window: 3
+  energy_landscape_eval:
+    do_energy_landscape_eval: false
+    energy_landscape_rollout_steps: 1
+    energy_landscape_ctxt_window: 3
+model:
+  # Shared fields
+  grid_size: 16
+  tubelet_size_enc: 1
+  use_activation_checkpointing: false
+  action_conditioning: token
+  proprio_encoding: none
+  num_frames_pred: 4
+  # Visual encoder config
+  visual_encoder:
+    enc_type: dino
+    enc_version: dinov3_vitl16
+    pretrain_enc_path: null
+    pretrain_enc_ckpt_key: null
+    embed_dim: 1024
+    enc_use_rope: null
+    enc_name: null
+    use_sdpa_enc: null
+    num_frames_enc: null
+    uniform_power: true
+  # Action encoder config
+  action_encoder:
+    action_tokens: 1
+    action_emb_dim: 0
+    act_mlp: false
+    action_encoder_inpred: true
+  # Proprio encoder config
+  proprio_encoder:
+    proprio_tokens: 0
+    proprio_emb_dim: 0
+    prop_mlp: false
+    proprio_encoder_inpred: false
+  # Predictor config
+  predictor:
+    tubelet_size: 1
+    pred_num_heads: 16
+    pred_depth: 12
+    pred_embed_dim: 1024
+    pred_use_extrinsics: false
+    pred_type: AdaLN
+    act_pred_projector: null
+    use_SiLU: null
+    use_rope: true
+  # VideoWM encoding()
+  wm_encoding:
+    batchify_video: true
+    dup_image: false
+    normalize_reps: false
+  # Rollout config
+  rollout_cfg:
+    rollout_steps: 2
+    train_rollout_prefixes: random
+    rollout_stop_gradient: true
+    ctxt_window_train_rollout: 3
+    do_parallel_rollout: null
+    do_sequential_rollout: true
+    prepend_gt: null
+    sampling_scheduler:
+      type: linear
+      start: 0.
+      end: 0.
+  # Attention config (passed as cfgs_attn_pattern to init_video_model)
+  attn:
+    local_window_time: 3
+    local_window_h: -1
+    local_window_w: -1
+  # Decoder heads config (optional - for visualization only)
+  # To enable, copy heads_cfg from your trained decoder config in configs/vjepa_wm/vm2m/open_source_decs/
+  heads_cfg:
+    architectures: {}
+    pretrain_dec_path:
+      # image_head: ${JEPAWM_CKPT}/vm2m/opensource_decs/step2_lpips_vm2m_dv3vitl_256_vjtra/jepa-latest.pth.tar
+optimization:
+  main_optimizer: transition_model
+  train_heads: false
+  transition_model:
+    iterations_per_epoch: 300
+    ipe_scale: 1.
+    clip_grad: 1
+    use_radamw: false
+    betas: [0.9, 0.995]
+    eps: 1.e-8
+    weight_decay: 1.e-7
+    final_weight_decay: 1.e-6
+    num_epochs: 315
+    warmup: 0
+    start_lr: 5.e-4
+    ref_lr: 5.e-4
+    final_lr: 5.e-4
+    mixed_precision: true
+evals:
+  separate: true
+  decode: false
+  eval_episodes: 32 # 64 for DROID, 32 for rcasa
+  nodes: 2 # 1 for DROID, 2 for rcasa
+  low_pri: true
+  obs: rgb
+  alpha: 0
+  override_cfgs_data: true # always True
+  override_datasets: false # False to eval droid on rcasa
+  wrapper_kwargs:
+    ctxt_window: 2
+    proprio_mode: predict_proprio # predict_proprio | compute_new_pose
+  dump_eval_configs: true
+  eval_cfg_paths:
+  # Robocasa
+  - configs/online_plan_evals/rcasa_custom/gd/place_L1_gd_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/gd/place_L2_gd_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/gd/reach_L1_gd_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/gd/reach_L2_gd_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+
+  - configs/online_plan_evals/rcasa_custom/reach_L1_cem_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/reach_L2_cem_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/place_L1_cem_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/place_L2_cem_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+
+  - configs/online_plan_evals/rcasa_custom/ng/reach_L1_ng_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/ng/reach_L2_ng_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/ng/place_L1_ng_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/ng/place_L2_ng_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+
+  - configs/online_plan_evals/rcasa_custom/adam/reach_L1_adam_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/adam/reach_L2_adam_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/adam/place_L1_adam_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  - configs/online_plan_evals/rcasa_custom/adam/place_L2_adam_sourcedset_H3_nas1_maxnorm005_scaleact_repeat5_fskip5_max60_ctxt2.yaml
+  # DROID
+    # - configs/online_plan_evals/droid/adam/droid_L2_adam_sourcedset_H3_nas3_maxnorm01_ctxt2_gH3.yaml
+    # - configs/online_plan_evals/droid/gd/droid_L2_gd_sourcedset_H3_nas3_maxnorm01_ctxt2_gH3.yaml
+    # - configs/online_plan_evals/droid/ng/droid_L2_ng_sourcedset_H3_nas3_maxnorm01_ctxt2_gH3.yaml
+    # - configs/online_plan_evals/droid/droid_L2_cem_sourcedset_H3_nas3_maxnorm01_ctxt2_gH3.yaml
+    # - configs/online_plan_evals/droid/adam/droid_L1_adam_sourcedset_H3_nas3_maxnorm01_ctxt2_gH3.yaml
+    # - configs/online_plan_evals/droid/gd/droid_L1_gd_sourcedset_H3_nas3_maxnorm01_ctxt2_gH3.yaml
+    # - configs/online_plan_evals/droid/ng/droid_L1_ng_sourcedset_H3_nas3_maxnorm01_ctxt2_gH3.yaml
+    # - configs/online_plan_evals/droid/droid_L1_cem_sourcedset_H3_nas3_maxnorm01_ctxt2_gH3.yaml
+unroll_decode_evals:
+  # comment out all mpk_manifest_patterns except liftcup_v0 for counterfactuals
+  wrapper_kwargs:
+    ctxt_window: 2
+    proprio_mode: predict_proprio # predict_proprio | compute_new_pose
+  specific_video: false
+  specific_video_path:
+  play_in_reverse: false
+  save_decoding_only: true
+  repeat_hardcode_act: 1
+  obs: rgb

--- a/configs/vjepa_wm/mw_final_sweep/mw_4f_fsk5_ask1_frac0.1_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save.yaml
+++ b/configs/vjepa_wm/mw_final_sweep/mw_4f_fsk5_ask1_frac0.1_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save.yaml
@@ -1,25 +1,27 @@
 app: vjepa_wm
-nodes: 2
+nodes: 4
 tasks_per_node: 8
 cpus_per_task: 16
-folder: ${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_2n
+folder: ${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.1_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save
+checkpoint_folder: ${JEPAWM_CKPT}/mw_final_sweep/mw_4f_fsk5_ask1_frac0.1_r224_pred_AdaLN_ftprop_depth6_repro_2roll_save
 data:
   # Dataset configuration
   dataset_type: custom
   datasets:
-    - Wall
+    - METAWORLD_HF
   datasets_weights: null
   seed: 234
+  dset_fraction: 0.1
   img_size: 224
   # Validation configuration
   validation:
     val_datasets: []
     val_datasets_1: null
-    num_frames_val: 8
+    num_frames_val: 18
     val_dataset_batch_size: 4
     val_dataset_drop_last: false
     val_dataset_fpcs: [8]
-    val_dataset_camera_views: null
+    val_dataset_camera_views: ["exterior_image_2_left"]
     val_viz_rank0_loader: false
   # DataLoader configuration
   loader:
@@ -35,7 +37,7 @@ data:
     state_skip: 1
     normalize_action: true
     traj_subset: true
-    filter_first_episodes: null
+    filter_first_episodes:
     filter_tasks: null
     num_hist: 3
     num_pred: 1
@@ -62,7 +64,7 @@ data_aug:
   - 1.777
   - 1.777
   reprob: 0.0
-  normalize: [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]]
+  normalize: [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
 logging:
   write_tag: jepa
   wandb:
@@ -104,7 +106,7 @@ model:
   grid_size: 16
   tubelet_size_enc: 1
   use_activation_checkpointing: false
-  action_conditioning: feature
+  action_conditioning: token
   proprio_encoding: feature
   num_frames_pred: 4
   # Visual encoder config
@@ -116,19 +118,19 @@ model:
     embed_dim: 384
     enc_use_rope: null
     enc_name: null
-    use_sdpa_enc: null
-    num_frames_enc: null
+    use_sdpa_enc: true
+    num_frames_enc: 16
     uniform_power: true
   # Action encoder config
   action_encoder:
-    action_tokens: 0
-    action_emb_dim: 10
+    action_tokens: 1
+    action_emb_dim: 0
     act_mlp: false
-    action_encoder_inpred: false
+    action_encoder_inpred: true
   # Proprio encoder config
   proprio_encoder:
     proprio_tokens: 0
-    proprio_emb_dim: 0
+    proprio_emb_dim: 16
     prop_mlp: false
     proprio_encoder_inpred: false
   # Predictor config
@@ -138,11 +140,10 @@ model:
     pred_depth: 6
     pred_embed_dim: 384
     pred_use_extrinsics: false
-    pred_type: dino_wm
+    pred_type: AdaLN
     act_pred_projector: false
     use_SiLU: false
     use_rope: true
-    use_sdpa: true
   # VideoWM encoding()
   wm_encoding:
     batchify_video: true
@@ -150,7 +151,7 @@ model:
     normalize_reps: false
   # Rollout config
   rollout_cfg:
-    rollout_steps: 1
+    rollout_steps: 2
     train_rollout_prefixes: random
     rollout_stop_gradient: true
     ctxt_window_train_rollout: 3
@@ -171,12 +172,12 @@ model:
   heads_cfg:
     architectures: {}
     pretrain_dec_path:
-      # image_head: ${JEPAWM_LOGS}/vm2m/opensource_decs/step2_lpips_vm2m_vits_vitldec_224_vjtrans05/jepa-latest.pth.tar
+      # image_head: ${JEPAWM_LOGS}/vm2m/opensource_decs/step2_lpips_vm2m_dv3_vits_256_vjtrans/jepa-latest.pth.tar
 optimization:
   main_optimizer: transition_model
   train_heads: false
   transition_model:
-    iterations_per_epoch: null
+    iterations_per_epoch: 3543
     ipe_scale: 1.
     clip_grad: 1
     use_radamw: false
@@ -192,17 +193,29 @@ optimization:
     mixed_precision: true
 evals:
   decode: false
-  eval_episodes: 96
-  nodes: 1
+  eval_episodes: 48
+  nodes: 2
   low_pri: true
-  obs: rgb
-  alpha: 0
+  obs: rgb_state
+  alpha: 0.1
+  dump_eval_configs: false
   eval_cfg_paths:
-  - configs/online_plan_evals/wall/adam/wall_L2_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L2_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L2_ng_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/wall_L2_cem_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/adam/wall_L1_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L1_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L1_ng_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/wall_L1_cem_sourcerandstate_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/mw/gd/reach_L2_gd_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/ng/reach_L2_ng_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/reach_L2_cem_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/adam/reach_L2_adam_sourcexp_H6_nas3_ctxt2.yaml
+
+    # - configs/online_plan_evals/mw/gd/reach_L1_gd_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/ng/reach_L1_ng_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/reach_L1_cem_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/adam/reach_L1_adam_sourcexp_H6_nas3_ctxt2.yaml
+    # reach-wall
+    # - configs/online_plan_evals/mw/gd/reach-wall_L2_gd_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/ng/reach-wall_L2_ng_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/reach-wall_L2_cem_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/adam/reach-wall_L2_adam_sourcexp_H6_nas3_ctxt2.yaml
+
+    # - configs/online_plan_evals/mw/gd/reach-wall_L1_gd_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/ng/reach-wall_L1_ng_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/reach-wall_L1_cem_sourcexp_H6_nas3_ctxt2.yaml
+    # - configs/online_plan_evals/mw/adam/reach-wall_L1_adam_sourcexp_H6_nas3_ctxt2.yaml

--- a/configs/vjepa_wm/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9.yaml
+++ b/configs/vjepa_wm/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9.yaml
@@ -1,26 +1,23 @@
 app: vjepa_wm
-nodes: 2
+nodes: 4
 tasks_per_node: 8
 cpus_per_task: 16
-folder: ${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_2n
+folder: ${JEPAWM_LOGS}/mw_final_sweep/mw_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9
 data:
   # Dataset configuration
   dataset_type: custom
   datasets:
-    - Wall
+    - METAWORLD_HF
   datasets_weights: null
-  seed: 234
+  seed: 1
   img_size: 224
   # Validation configuration
   validation:
     val_datasets: []
     val_datasets_1: null
-    num_frames_val: 8
+    num_frames_val: 18
     val_dataset_batch_size: 4
     val_dataset_drop_last: false
-    val_dataset_fpcs: [8]
-    val_dataset_camera_views: null
-    val_viz_rank0_loader: false
   # DataLoader configuration
   loader:
     batch_size: 8
@@ -35,9 +32,9 @@ data:
     state_skip: 1
     normalize_action: true
     traj_subset: true
-    filter_first_episodes: null
+    filter_first_episodes:
     filter_tasks: null
-    num_hist: 3
+    num_hist: 9
     num_pred: 1
     with_reward: false
     custom_teleop_dset: null
@@ -85,14 +82,14 @@ meta:
   load_opt_scale_epoch: true
   read_checkpoint: null
   pretrained_path:
-  seed: 234
+  seed: 1
   eval_freq: 1
   light_eval_freq: 300
   save_every_freq: 1
   dtype: bfloat16
   data_traj_rollout_eval:
     do_data_traj_rollout_eval: true
-    data_traj_eval_rollout_steps: 6
+    data_traj_eval_rollout_steps: 17
     data_traj_decode_gt: true
     data_traj_eval_ctxt_window: 3
   energy_landscape_eval:
@@ -106,7 +103,7 @@ model:
   use_activation_checkpointing: false
   action_conditioning: feature
   proprio_encoding: feature
-  num_frames_pred: 4
+  num_frames_pred: 10
   # Visual encoder config
   visual_encoder:
     enc_type: dino
@@ -116,13 +113,13 @@ model:
     embed_dim: 384
     enc_use_rope: null
     enc_name: null
-    use_sdpa_enc: null
-    num_frames_enc: null
+    use_sdpa_enc: true
+    num_frames_enc: 16
     uniform_power: true
   # Action encoder config
   action_encoder:
     action_tokens: 0
-    action_emb_dim: 10
+    action_emb_dim: 20
     act_mlp: false
     action_encoder_inpred: false
   # Proprio encoder config
@@ -141,7 +138,7 @@ model:
     pred_type: dino_wm
     act_pred_projector: false
     use_SiLU: false
-    use_rope: true
+    use_rope: null
     use_sdpa: true
   # VideoWM encoding()
   wm_encoding:
@@ -171,6 +168,7 @@ model:
   heads_cfg:
     architectures: {}
     pretrain_dec_path:
+      # state_head: ${JEPAWM_LOGS}/mw/step2_mw_state_head_dinovits_r224_2n/jepa-latest.pth.tar
       # image_head: ${JEPAWM_LOGS}/vm2m/opensource_decs/step2_lpips_vm2m_vits_vitldec_224_vjtrans05/jepa-latest.pth.tar
 optimization:
   main_optimizer: transition_model
@@ -191,18 +189,40 @@ optimization:
     final_lr: 5.e-4
     mixed_precision: true
 evals:
-  decode: false
-  eval_episodes: 96
-  nodes: 1
+  decode: False
+  eval_episodes: 48
+  nodes: 2
   low_pri: true
   obs: rgb
-  alpha: 0
+  sum_all_diffs: false
+  dump_eval_configs: false
   eval_cfg_paths:
-  - configs/online_plan_evals/wall/adam/wall_L2_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L2_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L2_ng_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/wall_L2_cem_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/adam/wall_L1_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L1_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L1_ng_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/wall_L1_cem_sourcerandstate_H6_nas6_ctxt2.yaml
+    - configs/online_plan_evals/mw/adam/reach_L2_adam_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/gd/reach_L2_gd_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/ng/reach_L2_ng_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/reach_L2_cem_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/adam/reach_L1_adam_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/gd/reach_L1_gd_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/ng/reach_L1_ng_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/reach_L1_cem_sourcexp_H6_nas3_ctxt2.yaml
+    #
+    # - configs/online_plan_evals/mw/ng/reach_L2_ng_sourcexp_H15_nas15_ctxt2_maxstp75_itr30.yaml
+    # - configs/online_plan_evals/mw/ng/reach_L2_ng_sourcexp_H15_nas15_ctxt2_maxstp75.yaml
+    # - configs/online_plan_evals/mw/reach_L2_cem_sourcexp_H15_nas15_ctxt2_maxstp75_itr30.yaml
+    # - configs/online_plan_evals/mw/reach_L2_cem_sourcexp_H15_nas15_ctxt2_maxstp75.yaml
+    # reach-wall
+    - configs/online_plan_evals/mw/adam/reach-wall_L2_adam_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/gd/reach-wall_L2_gd_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/ng/reach-wall_L2_ng_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/reach-wall_L2_cem_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/adam/reach-wall_L1_adam_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/gd/reach-wall_L1_gd_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/ng/reach-wall_L1_ng_sourcexp_H6_nas3_ctxt2.yaml
+    - configs/online_plan_evals/mw/reach-wall_L1_cem_sourcexp_H6_nas3_ctxt2.yaml
+    #
+    # - configs/online_plan_evals/mw/ng/reach-wall_L2_ng_sourcexp_H15_nas15_ctxt2_maxstp75_itr30.yaml
+    # - configs/online_plan_evals/mw/ng/reach-wall_L2_ng_sourcexp_H15_nas15_ctxt2_maxstp75.yaml
+    # - configs/online_plan_evals/mw/reach-wall_L2_cem_sourcexp_H15_nas15_ctxt2_maxstp75_itr30.yaml
+    # - configs/online_plan_evals/mw/reach-wall_L2_cem_sourcexp_H15_nas15_ctxt2_maxstp75.yaml
+  wrapper_kwargs:
+    ctxt_window: 2

--- a/configs/vjepa_wm/mz_sweep/mz_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n.yaml
+++ b/configs/vjepa_wm/mz_sweep/mz_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n.yaml
@@ -2,14 +2,16 @@ app: vjepa_wm
 nodes: 2
 tasks_per_node: 8
 cpus_per_task: 16
-folder: ${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_2n
+folder: ${JEPAWM_LOGS}/mz_sweep/mz_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n
+checkpoint_folder: ${JEPAWM_CKPT}/mz_sweep/mz_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save_2n
 data:
   # Dataset configuration
   dataset_type: custom
   datasets:
-    - Wall
+    - PointMaze
   datasets_weights: null
   seed: 234
+  dset_fraction: 0.1
   img_size: 224
   # Validation configuration
   validation:
@@ -45,7 +47,7 @@ data:
   droid:
     camera_frame: false
     camera_views:
-      - 2
+      - 2 # side camera 2
     droid_to_rcasa_action_format: 1
     rcasa_to_droid_action_format: false
     fps: 4
@@ -62,7 +64,7 @@ data_aug:
   - 1.777
   - 1.777
   reprob: 0.0
-  normalize: [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]]
+  normalize: [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
 logging:
   write_tag: jepa
   wandb:
@@ -87,7 +89,7 @@ meta:
   pretrained_path:
   seed: 234
   eval_freq: 1
-  light_eval_freq: 300
+  light_eval_freq: 200
   save_every_freq: 1
   dtype: bfloat16
   data_traj_rollout_eval:
@@ -104,7 +106,7 @@ model:
   grid_size: 16
   tubelet_size_enc: 1
   use_activation_checkpointing: false
-  action_conditioning: feature
+  action_conditioning: token
   proprio_encoding: feature
   num_frames_pred: 4
   # Visual encoder config
@@ -121,14 +123,14 @@ model:
     uniform_power: true
   # Action encoder config
   action_encoder:
-    action_tokens: 0
-    action_emb_dim: 10
+    action_tokens: 1
+    action_emb_dim: 0
     act_mlp: false
-    action_encoder_inpred: false
+    action_encoder_inpred: true
   # Proprio encoder config
   proprio_encoder:
     proprio_tokens: 0
-    proprio_emb_dim: 0
+    proprio_emb_dim: 16
     prop_mlp: false
     proprio_encoder_inpred: false
   # Predictor config
@@ -138,11 +140,10 @@ model:
     pred_depth: 6
     pred_embed_dim: 384
     pred_use_extrinsics: false
-    pred_type: dino_wm
+    pred_type: AdaLN
     act_pred_projector: false
     use_SiLU: false
     use_rope: true
-    use_sdpa: true
   # VideoWM encoding()
   wm_encoding:
     batchify_video: true
@@ -150,7 +151,7 @@ model:
     normalize_reps: false
   # Rollout config
   rollout_cfg:
-    rollout_steps: 1
+    rollout_steps: 2
     train_rollout_prefixes: random
     rollout_stop_gradient: true
     ctxt_window_train_rollout: 3
@@ -176,7 +177,7 @@ optimization:
   main_optimizer: transition_model
   train_heads: false
   transition_model:
-    iterations_per_epoch: null
+    iterations_per_epoch: 1139
     ipe_scale: 1.
     clip_grad: 1
     use_radamw: false
@@ -195,14 +196,16 @@ evals:
   eval_episodes: 96
   nodes: 1
   low_pri: true
-  obs: rgb
-  alpha: 0
+  obs: rgb_state
+  alpha: 0.1
+  dump_eval_configs: false
   eval_cfg_paths:
-  - configs/online_plan_evals/wall/adam/wall_L2_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L2_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L2_ng_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/wall_L2_cem_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/adam/wall_L1_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L1_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L1_ng_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/wall_L1_cem_sourcerandstate_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/mz/gd/mz_L1_gd_sourcerandstate_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/mz/gd/mz_L2_gd_sourcerandstate_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/mz/adam/mz_L1_adam_sourcerandstate_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/mz/adam/mz_L2_adam_sourcerandstate_H6_nas6_ctxt2.yaml
+
+    # - configs/online_plan_evals/mz/ng/mz_L2_ng_sourcerandstate_H6_nas6_ctxt2.yaml
+    - configs/online_plan_evals/mz/mz_L2_cem_sourcerandstate_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/mz/ng/mz_L1_ng_sourcerandstate_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/mz/mz_L1_cem_sourcerandstate_H6_nas6_ctxt2.yaml

--- a/configs/vjepa_wm/pt_sweep/pt_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save.yaml
+++ b/configs/vjepa_wm/pt_sweep/pt_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save.yaml
@@ -1,15 +1,17 @@
 app: vjepa_wm
-nodes: 2
+nodes: 4
 tasks_per_node: 8
 cpus_per_task: 16
-folder: ${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_2n
+folder: ${JEPAWM_LOGS}/pt_sweep/pt_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save
+checkpoint_folder: ${JEPAWM_CKPT}/pt_sweep/pt_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll_save
 data:
   # Dataset configuration
   dataset_type: custom
   datasets:
-    - Wall
+    - PushT
   datasets_weights: null
   seed: 234
+  dset_fraction: 0.1
   img_size: 224
   # Validation configuration
   validation:
@@ -62,7 +64,7 @@ data_aug:
   - 1.777
   - 1.777
   reprob: 0.0
-  normalize: [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]]
+  normalize: [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
 logging:
   write_tag: jepa
   wandb:
@@ -104,7 +106,7 @@ model:
   grid_size: 16
   tubelet_size_enc: 1
   use_activation_checkpointing: false
-  action_conditioning: feature
+  action_conditioning: token
   proprio_encoding: feature
   num_frames_pred: 4
   # Visual encoder config
@@ -118,17 +120,16 @@ model:
     enc_name: null
     use_sdpa_enc: null
     num_frames_enc: null
-    uniform_power: true
   # Action encoder config
   action_encoder:
-    action_tokens: 0
-    action_emb_dim: 10
+    action_tokens: 1
+    action_emb_dim: 0
     act_mlp: false
-    action_encoder_inpred: false
+    action_encoder_inpred: true
   # Proprio encoder config
   proprio_encoder:
     proprio_tokens: 0
-    proprio_emb_dim: 0
+    proprio_emb_dim: 16
     prop_mlp: false
     proprio_encoder_inpred: false
   # Predictor config
@@ -138,19 +139,18 @@ model:
     pred_depth: 6
     pred_embed_dim: 384
     pred_use_extrinsics: false
-    pred_type: dino_wm
+    pred_type: AdaLN
     act_pred_projector: false
+    uniform_power: true
     use_SiLU: false
     use_rope: true
-    use_sdpa: true
-  # VideoWM encoding()
   wm_encoding:
     batchify_video: true
     dup_image: false
     normalize_reps: false
   # Rollout config
   rollout_cfg:
-    rollout_steps: 1
+    rollout_steps: 2
     train_rollout_prefixes: random
     rollout_stop_gradient: true
     ctxt_window_train_rollout: 3
@@ -176,7 +176,7 @@ optimization:
   main_optimizer: transition_model
   train_heads: false
   transition_model:
-    iterations_per_epoch: null
+    iterations_per_epoch: 7741
     ipe_scale: 1.
     clip_grad: 1
     use_radamw: false
@@ -195,14 +195,16 @@ evals:
   eval_episodes: 96
   nodes: 1
   low_pri: true
-  obs: rgb
-  alpha: 0
+  obs: rgb_state
+  alpha: 0.1
+  dump_eval_configs: false
   eval_cfg_paths:
-  - configs/online_plan_evals/wall/adam/wall_L2_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L2_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L2_ng_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/wall_L2_cem_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/adam/wall_L1_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L1_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L1_ng_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/wall_L1_cem_sourcerandstate_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/pt/gd/pt_L1_gd_sourcedset_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/pt/gd/pt_L2_gd_sourcedset_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/pt/adam/pt_L1_adam_sourcedset_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/pt/adam/pt_L2_adam_sourcedset_H6_nas6_ctxt2.yaml
+
+    # - configs/online_plan_evals/pt/ng/pt_L2_ng_sourcedset_H6_nas6_ctxt2.yaml
+    - configs/online_plan_evals/pt/pt_L2_cem_sourcedset_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/pt/ng/pt_L1_ng_sourcedset_H6_nas6_ctxt2.yaml
+    # - configs/online_plan_evals/pt/pt_L1_cem_sourcedset_H6_nas6_ctxt2.yaml

--- a/configs/vjepa_wm/wall_sweep/wall_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll.yaml
+++ b/configs/vjepa_wm/wall_sweep/wall_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll.yaml
@@ -2,7 +2,8 @@ app: vjepa_wm
 nodes: 2
 tasks_per_node: 8
 cpus_per_task: 16
-folder: ${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_2n
+folder: ${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll
+checkpoint_folder: ${JEPAWM_CKPT}/wall_sweep/wall_4f_fsk5_ask1_frac0.1_r224_vjtranoaug_predAdaLN_ftprop_depth6_repro_2roll
 data:
   # Dataset configuration
   dataset_type: custom
@@ -10,6 +11,7 @@ data:
     - Wall
   datasets_weights: null
   seed: 234
+  dset_fraction: 0.1
   img_size: 224
   # Validation configuration
   validation:
@@ -35,7 +37,7 @@ data:
     state_skip: 1
     normalize_action: true
     traj_subset: true
-    filter_first_episodes: null
+    filter_first_episodes:
     filter_tasks: null
     num_hist: 3
     num_pred: 1
@@ -45,7 +47,7 @@ data:
   droid:
     camera_frame: false
     camera_views:
-      - 2
+      - 2 # side camera 2
     droid_to_rcasa_action_format: 1
     rcasa_to_droid_action_format: false
     fps: 4
@@ -62,7 +64,7 @@ data_aug:
   - 1.777
   - 1.777
   reprob: 0.0
-  normalize: [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5]]
+  normalize: [[0.485, 0.456, 0.406], [0.229, 0.224, 0.225]]
 logging:
   write_tag: jepa
   wandb:
@@ -87,7 +89,7 @@ meta:
   pretrained_path:
   seed: 234
   eval_freq: 1
-  light_eval_freq: 300
+  light_eval_freq: 200
   save_every_freq: 1
   dtype: bfloat16
   data_traj_rollout_eval:
@@ -104,7 +106,7 @@ model:
   grid_size: 16
   tubelet_size_enc: 1
   use_activation_checkpointing: false
-  action_conditioning: feature
+  action_conditioning: token
   proprio_encoding: feature
   num_frames_pred: 4
   # Visual encoder config
@@ -121,14 +123,14 @@ model:
     uniform_power: true
   # Action encoder config
   action_encoder:
-    action_tokens: 0
-    action_emb_dim: 10
+    action_tokens: 1
+    action_emb_dim: 0
     act_mlp: false
-    action_encoder_inpred: false
+    action_encoder_inpred: true
   # Proprio encoder config
   proprio_encoder:
     proprio_tokens: 0
-    proprio_emb_dim: 0
+    proprio_emb_dim: 16
     prop_mlp: false
     proprio_encoder_inpred: false
   # Predictor config
@@ -138,11 +140,10 @@ model:
     pred_depth: 6
     pred_embed_dim: 384
     pred_use_extrinsics: false
-    pred_type: dino_wm
+    pred_type: AdaLN
     act_pred_projector: false
     use_SiLU: false
     use_rope: true
-    use_sdpa: true
   # VideoWM encoding()
   wm_encoding:
     batchify_video: true
@@ -150,7 +151,7 @@ model:
     normalize_reps: false
   # Rollout config
   rollout_cfg:
-    rollout_steps: 1
+    rollout_steps: 2
     train_rollout_prefixes: random
     rollout_stop_gradient: true
     ctxt_window_train_rollout: 3
@@ -176,7 +177,7 @@ optimization:
   main_optimizer: transition_model
   train_heads: false
   transition_model:
-    iterations_per_epoch: null
+    iterations_per_epoch: 418
     ipe_scale: 1.
     clip_grad: 1
     use_radamw: false
@@ -195,14 +196,15 @@ evals:
   eval_episodes: 96
   nodes: 1
   low_pri: true
-  obs: rgb
-  alpha: 0
+  obs: rgb_state
+  alpha: 0.1
+  dump_eval_configs: false
   eval_cfg_paths:
-  - configs/online_plan_evals/wall/adam/wall_L2_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L2_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L2_ng_sourcerandstate_H6_nas6_ctxt2.yaml
+  # - configs/online_plan_evals/wall/adam/wall_L2_adam_sourcerandstate_H6_nas6_ctxt2.yaml
+  # - configs/online_plan_evals/wall/gd/wall_L2_gd_sourcerandstate_H6_nas6_ctxt2.yaml
+  # - configs/online_plan_evals/wall/ng/wall_L2_ng_sourcerandstate_H6_nas6_ctxt2.yaml
   - configs/online_plan_evals/wall/wall_L2_cem_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/adam/wall_L1_adam_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/gd/wall_L1_gd_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/ng/wall_L1_ng_sourcerandstate_H6_nas6_ctxt2.yaml
-  - configs/online_plan_evals/wall/wall_L1_cem_sourcerandstate_H6_nas6_ctxt2.yaml
+  # - configs/online_plan_evals/wall/adam/wall_L1_adam_sourcerandstate_H6_nas6_ctxt2.yaml
+  # - configs/online_plan_evals/wall/gd/wall_L1_gd_sourcerandstate_H6_nas6_ctxt2.yaml
+  # - configs/online_plan_evals/wall/ng/wall_L1_ng_sourcerandstate_H6_nas6_ctxt2.yaml
+  # - configs/online_plan_evals/wall/wall_L1_cem_sourcerandstate_H6_nas6_ctxt2.yaml

--- a/configs/vjepa_wm/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9.yaml
+++ b/configs/vjepa_wm/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9.yaml
@@ -2,7 +2,7 @@ app: vjepa_wm
 nodes: 2
 tasks_per_node: 8
 cpus_per_task: 16
-folder: ${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_save_2n
+folder: ${JEPAWM_LOGS}/wall_sweep/wall_4f_fsk5_ask1_r224_pred_dino_wm_depth6_noprop_repro_1roll_hist9
 data:
   # Dataset configuration
   dataset_type: custom
@@ -37,7 +37,7 @@ data:
     traj_subset: true
     filter_first_episodes: null
     filter_tasks: null
-    num_hist: 3
+    num_hist: 9
     num_pred: 1
     with_reward: false
     custom_teleop_dset: null
@@ -106,7 +106,7 @@ model:
   use_activation_checkpointing: false
   action_conditioning: feature
   proprio_encoding: feature
-  num_frames_pred: 4
+  num_frames_pred: 10
   # Visual encoder config
   visual_encoder:
     enc_type: dino
@@ -197,6 +197,7 @@ evals:
   low_pri: true
   obs: rgb
   alpha: 0
+  dump_eval_configs: false
   eval_cfg_paths:
   - configs/online_plan_evals/wall/adam/wall_L2_adam_sourcerandstate_H6_nas6_ctxt2.yaml
   - configs/online_plan_evals/wall/gd/wall_L2_gd_sourcerandstate_H6_nas6_ctxt2.yaml

--- a/evals/simu_env_planning/run_eval_grid.py
+++ b/evals/simu_env_planning/run_eval_grid.py
@@ -15,12 +15,14 @@ This script generates config files to run planning evals. It works by:
 3. Outputting configs to --out-dir (defaults to configs/cwtemp)
 
 Usage:
-    python -m evals.simu_env_planning.run_eval_grid --env droid --variant H3
+    python -m evals.simu_env_planning.run_eval_grid --env droid --variant H3 --alpha 0
     python -m evals.simu_env_planning.run_eval_grid --env metaworld
     python -m evals.simu_env_planning.run_eval_grid --env robocasa --variant reach place
     python -m evals.simu_env_planning.run_eval_grid --env maze
     python -m evals.simu_env_planning.run_eval_grid --env pusht
     python -m evals.simu_env_planning.run_eval_grid --env wall
+
+    --config path/to/cfg/to_override
 """
 
 import argparse
@@ -281,7 +283,7 @@ def main():
     print(
         f"python -m evals.main_distributed --fname {batch_path} --batch-launch "
         f"--array-parallelism 700 --account fair_amaia_cw_video --qos lowest --time 120 "
-        f"--submitit_folder {sample_conf['folder']}/submitit-evals-batches/ --use_config_folder --copy_code"
+        f"--submitit_folder {sample_conf['folder']}/submitit-evals-batches/ --copy_code"
     )
 
 

--- a/src/utils/distributed.py
+++ b/src/utils/distributed.py
@@ -5,22 +5,33 @@
 # LICENSE file in the root directory of this source tree.
 #
 
+import datetime
 import os
+import socket
 from pathlib import Path
 
 import torch
 import torch.distributed as dist
+from torch.distributed.elastic.utils.distributed import get_free_port
 
 from src.utils.logging import get_logger
 
 logger = get_logger()
 
 
-def init_distributed(port=37129, rank_and_world_size=(None, None)):
-    # try to set all environment variables to avoid triggering a segfault
-    # environment variables can be reallocated during the execution of torch.distributed.init_process_group
-    # the idea is a race condition may trigger if init_progress_group is modifying an environment variable at
-    # the same time as Python, so we try to set all environs before initializing distributed
+def _get_port(world_size, default_port=37129):
+    # If other jobs are running on the node, the default_port might be in use by another process. If we are
+    # only using 1 GPU, we can avoid this by just picking a free port
+    return get_free_port() if world_size == 1 else default_port
+
+
+def init_distributed(
+    port=None,
+    rank_and_world_size=(None, None),
+    nccl_timeout_minutes=None,
+):
+    # Set all environment variables *before* calling `torch.distributed.init_process_group`. `init_process_group` may
+    # reallocate environment variables; modifying them after could trigger a race condition leading to a segfault.
     if "SLURM_JOB_ID" in os.environ:
         # Use the slurm_tmpdir (if it exists) instead of /tmp
         tmpdir = Path(f"/scratch/slurm_tmpdir/{os.environ['SLURM_JOB_ID']}")
@@ -30,31 +41,94 @@ def init_distributed(port=37129, rank_and_world_size=(None, None)):
     if dist.is_available() and dist.is_initialized():
         return dist.get_world_size(), dist.get_rank()
 
+    # defaults
     rank, world_size = rank_and_world_size
     os.environ["MASTER_ADDR"] = "localhost"
 
-    if (rank is None) or (world_size is None):
+    # torchrun
+    dist_keys = ["RANK", "WORLD_SIZE", "LOCAL_RANK"]
+    dist_env_set = all([key in os.environ for key in dist_keys])
+
+    # If rank and world_size are explicitly provided, set env vars for compatibility
+    # Fix local launcher on interactive node
+    if (rank is not None) and (world_size is not None) and not dist_env_set:
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["RANK"] = str(rank)
+        os.environ["LOCAL_RANK"] = str(rank)
+        dist_env_set = True
+
+    # submitit / hydra.submitit
+    if not dist_env_set and ((rank is None) or (world_size is None)):
         try:
-            world_size = int(os.environ["SLURM_NTASKS"])
-            rank = int(os.environ["SLURM_PROCID"])
-            os.environ["MASTER_ADDR"] = os.environ["HOSTNAME"]
-        except Exception:
-            logger.info("SLURM vars not set (distributed training not available)")
+            os.environ["WORLD_SIZE"] = os.environ["SLURM_NTASKS"]
+            os.environ["RANK"] = os.environ["SLURM_PROCID"]
+            os.environ["LOCAL_RANK"] = os.environ["SLURM_LOCALID"]
+            # $HOSTNAME is not always exported to os.environ
+            os.environ["MASTER_ADDR"] = os.environ["HOSTNAME"] if "HOSTNAME" in os.environ else socket.gethostname()
+        except Exception as e:
+            logger.info(f"SLURM vars not set (distributed training not available): {e}")
             world_size, rank = 1, 0
             return world_size, rank
 
     try:
+        world_size = int(os.environ["WORLD_SIZE"])
+        rank = int(os.environ["RANK"])
+        if port is None:
+            port = _get_port(world_size)
         os.environ["MASTER_PORT"] = str(port)
-        torch.distributed.init_process_group(backend="nccl", world_size=world_size, rank=rank)
+        # Increase timeout for large-scale multi-node jobs
+        # Also need longer timeout for mixed video+image training where different loaders
+        # (e.g., Instagram video loader) can take a very long time to fetch the first sample
+        nccl_timeout = None
+        if nccl_timeout_minutes is not None:
+            logger.info(f"Initializing distributed with timeout={nccl_timeout_minutes} minutes")
+            nccl_timeout = datetime.timedelta(minutes=nccl_timeout_minutes)
+        torch.distributed.init_process_group(
+            backend="cpu:gloo,cuda:nccl",
+            world_size=world_size,
+            rank=rank,
+            timeout=nccl_timeout,
+        )
     except Exception as e:
-        world_size, rank = 1, 0
-        logger.info(f"Rank: {rank}. Distributed training not available {e}")
+        logger.error(f"Rank {rank}: Distributed training initialization FAILED: {e}")
+        logger.error("This is a fatal error for multi-GPU training. Check network connectivity.")
+        # Re-raise the exception instead of silently continuing with world_size=1
+        # This prevents confusing errors later when DDP fails
+        raise RuntimeError(
+            f"Failed to initialize distributed training: {e}. "
+            f"Rank={rank}, World={world_size}, Master={os.environ.get('MASTER_ADDR')}"
+        ) from e
 
     return world_size, rank
 
 
-class AllGather(torch.autograd.Function):
+def is_initialized() -> bool:
+    if not dist.is_available():
+        return False
+    if not dist.is_initialized():
+        return False
+    for key in ["RANK", "LOCAL_RANK", "WORLD_SIZE"]:
+        if key not in os.environ:
+            return False
+    return True
 
+
+def get_local_rank() -> int:
+    assert is_initialized()
+    return int(os.environ["LOCAL_RANK"])
+
+
+def get_global_rank() -> int:
+    assert is_initialized()
+    return int(os.environ["RANK"])
+
+
+def get_world_size() -> int:
+    assert is_initialized()
+    return int(os.environ["WORLD_SIZE"])
+
+
+class AllGather(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x):
         if dist.is_available() and dist.is_initialized() and (dist.get_world_size() > 1):
@@ -76,7 +150,6 @@ class AllGather(torch.autograd.Function):
 
 
 class AllReduceSum(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, x):
         if dist.is_available() and dist.is_initialized() and (dist.get_world_size() > 1):
@@ -90,7 +163,6 @@ class AllReduceSum(torch.autograd.Function):
 
 
 class AllReduce(torch.autograd.Function):
-
     @staticmethod
     def forward(ctx, x):
         if dist.is_available() and dist.is_initialized() and (dist.get_world_size() > 1):


### PR DESCRIPTION
## Describe your changes

Code changes:
- Rename droid_fraction -> dset_fraction across all dataset classes
- Add dset_fraction support to metaworld, point_maze, pusht, robocasa, wall datasets
- Fix pusht shapes slicing bug
- Improve distributed init: auto port selection, torchrun support, NCCL timeout config
- Replace print() with log.info() in traj_dset
- Update run_eval_grid.py usage
- Extend logs_plan_joint_per_design_choice.py with multi-method YAML support

New files:
- droid_traj_stats.py: precompute DROID trajectory lengths
- 3 design-choice plot YAMLs (W_extended, data_scaling, data_scaling_droid_rcasa)
- 8 representative configs for data-fraction and context-length ablations

## Does this PR touch common code? [x] YES [ ] NO

<!--- Check the corresponding box -->

## Test Plan (optional if not touching common code)

<!--- If you tested this change by running code, please share links to the output or logs, along with any summary or
    explanation needed for a reviewer to understand that this change works as intended. -->



<!--- Finally, please add one or more reviewers.  If this PR is not ready for review, please make it (or convert to)
    a draft. -->
